### PR TITLE
CRF package improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "r.lsp.promptToInstall": false
+}

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -3,7 +3,8 @@
 ## ApexRMS, November 2024
 ## -------------------------------
 
-# set up workspace ---------------------------------------------------------
+# Set up workspace -------------------------------------------------------------
+
 packageDir <- (Sys.getenv("ssim_package_directory"))
 
 sourceScripts <- list.files(
@@ -14,13 +15,20 @@ sourceScripts <- list.files(
 
 invisible(lapply(sourceScripts, source))
 
-myScenario <- scenario() # Get the SyncroSim Scenario that is currently running
+progressBar(type = "message", 
+            message = "Loading input data and setting up scenario")
+
+# Get the SyncroSim Scenario that is currently running
+myScenario <- scenario() 
 
 # Retrieve the transfer directory for storing output rasters
 e <- ssimEnvironment()
 transferDir <- e$TransferDirectory
 
-# Load raster input datasheets -----------------------------------------------
+
+
+# Load raster input datasheets -------------------------------------------------
+
 trainingRasterDataframe <- datasheet(
   myScenario,
   name = "ecoClassify_InputTrainingRasters"
@@ -41,7 +49,10 @@ if (!is.null(classifierOptions$setSeed) && !is.na(classifierOptions$setSeed)) {
   set.seed(classifierOptions$setSeed)
 }
 
-# Assign variables ----------------------------------------------------------
+
+
+# Assign variables -------------------------------------------------------------
+
 inputVariables <- assignVariables(
   myScenario,
   trainingRasterDataframe,
@@ -49,29 +60,37 @@ inputVariables <- assignVariables(
 )
 timestepList <- inputVariables[[1]]
 nObs <- inputVariables[[2]]
-filterResolution <- inputVariables[[3]] # TO DO: give warnings for lower limits (must be >=1?)
-filterPercent <- inputVariables[[4]]
-applyFiltering <- inputVariables[[5]]
-applyContextualization <- inputVariables[[6]]
-contextualizationWindowSize <- inputVariables[[7]]
-modelType <- inputVariables[[8]]
-modelTuning <- inputVariables[[9]]
-setManualThreshold <- inputVariables[[10]]
-manualThreshold <- inputVariables[[11]]
-normalizeRasters <- inputVariables[[12]]
-rasterDecimalPlaces <- inputVariables[[13]]
+#filterResolution <- inputVariables[[3]] # TO DO: give warnings for lower limits (must be >=1?)
+#filterPercent <- inputVariables[[4]]
+#applyFiltering <- inputVariables[[5]]
+applyContextualization <- inputVariables[[3]]
+contextualizationWindowSize <- inputVariables[[4]]
+modelType <- inputVariables[[5]]
+modelTuning <- inputVariables[[6]]
+setManualThreshold <- inputVariables[[7]]
+manualThreshold <- inputVariables[[8]]
+normalizeRasters <- inputVariables[[9]]
+rasterDecimalPlaces <- inputVariables[[10]]
 
-
-## check if multiprocessing is selected
+# Check if multiprocessing is selected
 mulitprocessingSheet <- datasheet(myScenario, "core_Multiprocessing")
 nCores <- setCores(mulitprocessingSheet)
 
-# extract list of training and ground truth rasters ----------------
+
+
+# Extract list of training and ground truth rasters ----------------------------
+
 trainingRasterList <- extractRasters(trainingRasterDataframe, column = 2)
 
 groundTruthRasterList <- extractRasters(trainingRasterDataframe, column = 3)
 
-# round rasters to integer if selected ----------------------------------
+
+
+# Pre-processing ---------------------------------------------------------------
+
+progressBar(type = "message", message = "Pre-processing input data")
+
+# Round rasters to integer, if selected
 if (
   is.numeric(rasterDecimalPlaces) &&
     length(rasterDecimalPlaces) > 0 &&
@@ -83,36 +102,49 @@ if (
   trainingRasterList <- roundedRasters
 }
 
-# normalize training rasters if selected -------------------------------------
+# Normalize training rasters, if selected
 if (normalizeRasters == TRUE) {
   trainingRasterList <- normalizeRaster(trainingRasterList)
 }
 
-# apply contextualization to training rasters if selected ---------------------
+# Apply contextualization to training rasters, if selected
 if (applyContextualization == TRUE) {
   trainingRasterList <- contextualizeRaster(trainingRasterList)
 }
 
-# reclassify ground truth rasters --------------------------------------------
+# Reclassify ground truth rasters
 groundTruthRasterList <- reclassifyGroundTruth(groundTruthRasterList)
 
-# extract covariate rasters and convert to correct data type -----------------
+# Extract covariate rasters and convert to correct data type
 trainingCovariateRaster <- processCovariates(
   trainingCovariateDataframe,
   modelType
 )
 
-# add covariate data to training rasters -------------------------------------
+# Add covariate data to training rasters
 trainingRasterList <- addCovariates(
   trainingRasterList,
   trainingCovariateRaster
 )
 
-# check and mask NA values in training rasters -------------------
-# removed mask, now it just adds a message to run log if uneven number of NA values across training data
+# Check for NA values in training rasters
+# NOTE: Masking is not applied, but a message is returned if there are an uneven
+#       number of NA values across the training data
 checkNA(trainingRasterList)
 
-# Setup empty dataframes to accept output in SyncroSim datasheet format ------
+# Separate training and testing data
+splitData <- splitTrainTest(
+  trainingRasterList,
+  groundTruthRasterList,
+  nObs
+)
+allTrainData <- splitData[[1]]
+allTestData <- splitData[[2]]
+
+
+
+# Setup empty dataframes to accept output in SyncroSim datasheet format --------
+
 rasterOutputDataframe <- data.frame(
   Timestep = numeric(0),
   PredictedUnfiltered = character(0),
@@ -131,16 +163,12 @@ modelOutputDataframe <- data.frame(Statistic = character(0), Value = numeric(0))
 
 rgbOutputDataframe <- data.frame(Timestep = numeric(0), RGBImage = character(0))
 
-# separate training and testing data -------------------------------------------
-splitData <- splitTrainTest(
-  trainingRasterList,
-  groundTruthRasterList,
-  nObs
-)
-allTrainData <- splitData[[1]]
-allTestData <- splitData[[2]]
 
-## Train model -----------------------------------------------------------------
+
+# Train model ------------------------------------------------------------------
+
+progressBar(type = "message", message = "Training model")
+
 if (modelType == "MaxEnt") {
   modelOut <- getMaxentModel(allTrainData, nCores, modelTuning)
   if (setManualThreshold == FALSE) {
@@ -185,6 +213,7 @@ rastLayerHistogram <- getRastLayerHistogram(
 )
 
 if (modelType == "CNN") {
+  
   # Save Torch weights separately
   model_weights_path <- file.path(transferDir, "model_weights.pt")
   torch::torch_save(modelOut$model$state_dict(), model_weights_path)
@@ -193,11 +222,13 @@ if (modelType == "CNN") {
   metadata <- modelOut[names(modelOut) != "model"]
   metadata_path <- file.path(transferDir, "model_metadata.rds")
   saveRDS(metadata, metadata_path)
+
 } else {
   model_path <- file.path(transferDir, "model.rds")
   saveRDS(modelOut, model_path)
 }
-# add to output datasheet
+
+# Add to output datasheet
 if (modelType == "CNN") {
   modelObjectOutputDataframe <- data.frame(
     Model = metadata_path,
@@ -212,7 +243,8 @@ if (modelType == "CNN") {
     Weights = ""
   )
 }
-# save model object to output datasheet
+
+# Save model object to output datasheet
 variableImportanceOutput <- plotVariableImportance(
   variableImportance,
   transferDir
@@ -221,14 +253,21 @@ variableImportanceOutput <- plotVariableImportance(
 variableImportancePlot <- variableImportanceOutput[[1]]
 varImportanceOutputImage <- variableImportanceOutput[[2]]
 
-# generate dataframe
+# Generate dataframe
 varImportanceOutputDataframe <- as.data.frame(variableImportance) %>%
   tibble::rownames_to_column("Variable") %>%
   rename(Importance = "variableImportance")
 
-## Predict presence for training rasters in each timestep group ----------------
+
+
+
+# Predict presence for training rasters in each timestep group -----------------
+
+progressBar(type = "message", message = "Predict training rasters")
+
 for (t in seq_along(trainingRasterList)) {
-  # get timestep for the current raster
+  
+  # Get timestep for the current raster
   timestep <- timestepList[t]
 
   if (modelType == "CNN") {
@@ -249,12 +288,9 @@ for (t in seq_along(trainingRasterList)) {
   predictedPresence <- predictionRasters[[1]]
   probabilityRaster <- predictionRasters[[2]]
 
-  # generate rasterDataframe based on filtering argument
+  # Generate rasterDataframe based on filtering argument
   rasterOutputDataframe <- generateRasterDataframe(
-    applyFiltering,
     predictedPresence,
-    filterResolution,
-    filterPercent,
     category = "training",
     timestep,
     transferDir,
@@ -262,10 +298,10 @@ for (t in seq_along(trainingRasterList)) {
     hasGroundTruth = TRUE
   )
 
-  # define GroundTruth raster
+  # Define GroundTruth raster
   groundTruth <- groundTruthRasterList[[t]]
 
-  # define RGB data frame
+  # Define RGB data frame
   rgbOutputDataframe <- getRgbDataframe(
     rgbOutputDataframe,
     category = "training",
@@ -273,7 +309,7 @@ for (t in seq_along(trainingRasterList)) {
     transferDir
   )
 
-  # save files
+  # Save files
   saveFiles(
     predictedPresence,
     groundTruth,
@@ -284,6 +320,8 @@ for (t in seq_along(trainingRasterList)) {
     transferDir
   )
 }
+
+progressBar(type = "message", message = "Calculating summary statistics")
 
 # Predict response based on range of values
 responseHistogram <- predictResponseHistogram(
@@ -297,7 +335,7 @@ histogramJoin <- responseHistogram %>%
 
 plotLayerHistogram(histogramJoin, transferDir)
 
-# add to output datasheet
+# Add to output datasheet
 layerHistogramPlotOutputDataframe <- data.frame(
   LayerHistogramPlot = file.path(paste0(
     transferDir,
@@ -305,7 +343,8 @@ layerHistogramPlotOutputDataframe <- data.frame(
   ))
 )
 
-# calculate mean values for model statistics -----------------------------------
+# Calculate mean values for model statistics --------------------
+
 outputDataframes <- calculateStatistics(
   modelOut,
   allTestData,
@@ -318,7 +357,8 @@ confusionOutputDataframe <- outputDataframes[[1]]
 modelOutputDataframe <- outputDataframes[[2]]
 confusionMatrixPlot <- outputDataframes[[3]]
 
-# generate model chart dataframe ----------------------------------------------
+# Generate model chart dataframe --------------------------------
+
 modelChartDataframe <- data.frame(
   Accuracy = modelOutputDataframe %>%
     filter(Statistic == "accuracy") %>%
@@ -334,13 +374,13 @@ modelChartDataframe <- data.frame(
     pull(Value)
 )
 
-# make a confusion matrix output dataframe
+# Make a confusion matrix output dataframe
 ggsave(
   filename = file.path(paste0(transferDir, "/ConfusionMatrixPlot.png")),
   confusionMatrixPlot
 )
 
-# add to output datasheet
+# Add to output datasheet
 confusionMatrixPlotOutputDataframe <- data.frame(
   ConfusionMatrixPlot = file.path(paste0(
     transferDir,
@@ -348,12 +388,15 @@ confusionMatrixPlotOutputDataframe <- data.frame(
   ))
 )
 
-# save filter resolution and threshold to input datasheet ----------------------
-filterOutputDataframe <- data.frame(
-  applyFiltering = applyFiltering,
-  filterResolution = filterResolution,
-  filterPercent = filterPercent
-)
+# Save filter resolution and threshold to input datasheet ----------------------
+
+progressBar(type = "message", message = "Saving results")
+
+# filterOutputDataframe <- data.frame(
+#   applyFiltering = applyFiltering,
+#   filterResolution = filterResolution,
+#   filterPercent = filterPercent
+# )
 
 if (is.null(rasterDecimalPlaces)) {
   rasterDecimalPlaces <- ""
@@ -364,9 +407,12 @@ if (is.null(contextualizationWindowSize)) {
 
 classifierOptionsOutputDataframe <- data.frame(
   nObs = format(nObs, scientific = FALSE),
+  modelType = modelType
+)
+
+advClassifierOptionsOutputDataframe <- data.frame(
   normalizeRasters = normalizeRasters,
   rasterDecimalPlaces = rasterDecimalPlaces,
-  modelType = modelType,
   modelTuning = modelTuning,
   setManualThreshold = setManualThreshold,
   manualThreshold = threshold,
@@ -375,17 +421,22 @@ classifierOptionsOutputDataframe <- data.frame(
 )
 
 # Save dataframes back to SyncroSim library's output datasheets ----------------
-
-saveDatasheet(
-  myScenario,
-  data = filterOutputDataframe,
-  name = "ecoClassify_PostProcessingOptions"
-)
+# saveDatasheet(
+#   myScenario,
+#   data = filterOutputDataframe,
+#   name = "ecoClassify_PostProcessingOptions"
+# )
 
 saveDatasheet(
   myScenario,
   data = classifierOptionsOutputDataframe,
   name = "ecoClassify_ClassifierOptions"
+)
+
+saveDatasheet(
+  myScenario,
+  data = advClassifierOptionsOutputDataframe,
+  name = "ecoClassify_AdvancedClassifierOptions"
 )
 
 saveDatasheet(
@@ -448,3 +499,4 @@ saveDatasheet(
   data = modelChartDataframe,
   name = "ecoClassify_ModelChartData"
 )
+

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -15,16 +15,17 @@ sourceScripts <- list.files(
 
 invisible(lapply(sourceScripts, source))
 
-progressBar(type = "message", 
-            message = "Loading input data and setting up scenario")
+progressBar(
+  type = "message",
+  message = "Loading input data and setting up scenario"
+)
 
 # Get the SyncroSim Scenario that is currently running
-myScenario <- scenario() 
+myScenario <- scenario()
 
 # Retrieve the transfer directory for storing output rasters
 e <- ssimEnvironment()
 transferDir <- e$TransferDirectory
-
 
 
 # Load raster input datasheets -------------------------------------------------
@@ -50,7 +51,6 @@ if (!is.null(classifierOptions$setSeed) && !is.na(classifierOptions$setSeed)) {
 }
 
 
-
 # Assign variables -------------------------------------------------------------
 
 inputVariables <- assignVariables(
@@ -60,9 +60,6 @@ inputVariables <- assignVariables(
 )
 timestepList <- inputVariables[[1]]
 nObs <- inputVariables[[2]]
-#filterResolution <- inputVariables[[3]] # TO DO: give warnings for lower limits (must be >=1?)
-#filterPercent <- inputVariables[[4]]
-#applyFiltering <- inputVariables[[5]]
 applyContextualization <- inputVariables[[3]]
 contextualizationWindowSize <- inputVariables[[4]]
 modelType <- inputVariables[[5]]
@@ -77,13 +74,11 @@ mulitprocessingSheet <- datasheet(myScenario, "core_Multiprocessing")
 nCores <- setCores(mulitprocessingSheet)
 
 
-
 # Extract list of training and ground truth rasters ----------------------------
 
 trainingRasterList <- extractRasters(trainingRasterDataframe, column = 2)
 
 groundTruthRasterList <- extractRasters(trainingRasterDataframe, column = 3)
-
 
 
 # Pre-processing ---------------------------------------------------------------
@@ -142,7 +137,6 @@ allTrainData <- splitData[[1]]
 allTestData <- splitData[[2]]
 
 
-
 # Setup empty dataframes to accept output in SyncroSim datasheet format --------
 
 rasterOutputDataframe <- data.frame(
@@ -162,7 +156,6 @@ confusionOutputDataframe <- data.frame(
 modelOutputDataframe <- data.frame(Statistic = character(0), Value = numeric(0))
 
 rgbOutputDataframe <- data.frame(Timestep = numeric(0), RGBImage = character(0))
-
 
 
 # Train model ------------------------------------------------------------------
@@ -213,7 +206,6 @@ rastLayerHistogram <- getRastLayerHistogram(
 )
 
 if (modelType == "CNN") {
-  
   # Save Torch weights separately
   model_weights_path <- file.path(transferDir, "model_weights.pt")
   torch::torch_save(modelOut$model$state_dict(), model_weights_path)
@@ -222,7 +214,6 @@ if (modelType == "CNN") {
   metadata <- modelOut[names(modelOut) != "model"]
   metadata_path <- file.path(transferDir, "model_metadata.rds")
   saveRDS(metadata, metadata_path)
-
 } else {
   model_path <- file.path(transferDir, "model.rds")
   saveRDS(modelOut, model_path)
@@ -259,14 +250,11 @@ varImportanceOutputDataframe <- as.data.frame(variableImportance) %>%
   rename(Importance = "variableImportance")
 
 
-
-
 # Predict presence for training rasters in each timestep group -----------------
 
 progressBar(type = "message", message = "Predict training rasters")
 
 for (t in seq_along(trainingRasterList)) {
-  
   # Get timestep for the current raster
   timestep <- timestepList[t]
 
@@ -392,11 +380,6 @@ confusionMatrixPlotOutputDataframe <- data.frame(
 
 progressBar(type = "message", message = "Saving results")
 
-# filterOutputDataframe <- data.frame(
-#   applyFiltering = applyFiltering,
-#   filterResolution = filterResolution,
-#   filterPercent = filterPercent
-# )
 
 if (is.null(rasterDecimalPlaces)) {
   rasterDecimalPlaces <- ""
@@ -421,12 +404,6 @@ advClassifierOptionsOutputDataframe <- data.frame(
 )
 
 # Save dataframes back to SyncroSim library's output datasheets ----------------
-# saveDatasheet(
-#   myScenario,
-#   data = filterOutputDataframe,
-#   name = "ecoClassify_PostProcessingOptions"
-# )
-
 saveDatasheet(
   myScenario,
   data = classifierOptionsOutputDataframe,
@@ -499,4 +476,3 @@ saveDatasheet(
   data = modelChartDataframe,
   name = "ecoClassify_ModelChartData"
 )
-

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -237,52 +237,61 @@ if (!is_empty(trainTimestepList)) {
       unfilteredTrainFilepath
     )
 
-    for (i in 1:dim(ruleReclassDataframe)[1]) {
-      if (!is.na(unfilteredTrainFilepath)) {
-        # Load rule raster
-        ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
-
-        # Categorical vs. Continuous
+    if (nrow(ruleReclassDataframe) == 0) {
+      updateRunLog(
+        "No rule-based reclassification rules found. Skipping reclassification.",
+        type = "warning"
+      )
+    } else {
+      for (i in 1:dim(ruleReclassDataframe)[1]) {
         if (
-          ruleReclassDataframe$ruleMinValue[i] ==
-            ruleReclassDataframe$ruleMaxValue[i]
+          !is.null(unfilteredTrainFilepath) && !is.na(unfilteredTrainFilepath)
         ) {
-          # Reclass table
-          reclassTable <- matrix(
-            c(
-              ruleReclassDataframe$ruleMinValue[i],
-              as.numeric(paste(ruleReclassDataframe$ruleReclassValue[i]))
-            ),
-            ncol = 2,
-            byrow = TRUE
-          )
+          # Load rule raster
+          ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
 
-          # Reclassify categorical
-          reclassedUnfilteredTrain[ruleRaster == reclassTable[, 1]] <-
-            reclassTable[, 2]
-        } else {
-          # Reclass table
-          reclassTable <- matrix(
-            c(
-              ruleReclassDataframe$ruleMinValue[i],
-              ruleReclassDataframe$ruleMaxValue[i],
-              as.numeric(paste(ruleReclassDataframe$ruleReclassValue[i]))
-            ),
-            ncol = 3,
-            byrow = T
-          )
-          # Reclassify continuous
-          ruleReclassRaster <- classify(ruleRaster, reclassTable, others = NA)
-          reclassedUnfilteredTrain[] <- mask(
-            unfilteredTrainRaster,
-            ruleReclassRaster,
-            maskvalue = as.numeric(paste(ruleReclassDataframe$ruleReclassValue[
-              i
-            ])),
-            updatevalue = as.numeric(paste(ruleReclassDataframe$ruleReclassValue[
-              i
-            ]))
-          )
+          # Categorical vs. Continuous
+          if (
+            ruleReclassDataframe$ruleMinValue[i] ==
+              ruleReclassDataframe$ruleMaxValue[i]
+          ) {
+            # Reclass table
+            reclassTable <- matrix(
+              c(
+                ruleReclassDataframe$ruleMinValue[i],
+                as.numeric(paste(ruleReclassDataframe$ruleReclassValue[i]))
+              ),
+              ncol = 2,
+              byrow = TRUE
+            )
+
+            # Reclassify categorical
+            reclassedUnfilteredTrain[ruleRaster == reclassTable[, 1]] <-
+              reclassTable[, 2]
+          } else {
+            # Reclass table
+            reclassTable <- matrix(
+              c(
+                ruleReclassDataframe$ruleMinValue[i],
+                ruleReclassDataframe$ruleMaxValue[i],
+                as.numeric(paste(ruleReclassDataframe$ruleReclassValue[i]))
+              ),
+              ncol = 3,
+              byrow = T
+            )
+            # Reclassify continuous
+            ruleReclassRaster <- classify(ruleRaster, reclassTable, others = NA)
+            reclassedUnfilteredTrain[] <- mask(
+              unfilteredTrainRaster,
+              ruleReclassRaster,
+              maskvalue = as.numeric(paste(ruleReclassDataframe$ruleReclassValue[
+                i
+              ])),
+              updatevalue = as.numeric(paste(ruleReclassDataframe$ruleReclassValue[
+                i
+              ]))
+            )
+          }
         }
       }
     }

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -210,12 +210,10 @@ for (t in predTimestepList) {
       transferDir
     )
 
-    # Rename column
-    names(filteredPredicting)[2] <-
-      # Combine results
-      predictingOutputDataframe$ClassifiedFiltered[
-        predictingOutputDataframe$Timestep == t
-      ] <- filteredPredicting$PredictedFiltered
+    # Combine results
+    predictingOutputDataframe$ClassifiedFiltered[
+      predictingOutputDataframe$Timestep == t
+    ] <- filteredPredicting$PredictedFiltered
   }
 }
 

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -1,0 +1,210 @@
+## ---------------------------------------
+## ecoClassify - Filtering training or predicting steps
+## ApexRMS, November 2024
+## ---------------------------------------
+
+# Set up workspace -------------------------------------------------------------
+
+packageDir <- (Sys.getenv("ssim_package_directory"))
+
+sourceScripts <- list.files(
+  path = file.path(packageDir, "/functions"),
+  pattern = "\\.[rR]$",
+  full.names = TRUE
+)
+
+invisible(lapply(sourceScripts, source))
+
+progressBar(type = "message", 
+            message = "Loading input data and setting up scenario")
+
+# Get the SyncroSim Scenario that is currently running
+myScenario <- scenario()
+
+# Retrieve the transfer directory for storing output rasters
+e <- ssimEnvironment()
+transferDir <- e$TransferDirectory
+
+
+
+# Load post-processing settings ------------------------------------------------
+
+# Filtering -----------------------------------------------------
+
+postProcessingDataframe <- datasheet(
+  myScenario,
+  name = "ecoClassify_PostProcessingFilter")
+
+filterResolution <- postProcessingDataframe$filterResolution
+filterPercent <- postProcessingDataframe$filterPercent
+applyFiltering <- postProcessingDataframe$applyFiltering
+
+# Apply default filtering values if not specified
+if (is.na(filterResolution) && applyFiltering == TRUE) {
+  filterResolution <- 5
+  updateRunLog(
+    "Filter resolution was not supplied; using default value of 5",
+    type = "info"
+  )
+}
+if (is.na(filterPercent) && applyFiltering == TRUE) {
+  filterPercent <- 0.25
+  updateRunLog(
+    "Filter percent was not supplied; using default value of 0.25",
+    type = "info"
+  )
+}
+
+# Output datasheets ---------------------------------------------
+
+trainingOutputDataframe <- datasheet(
+  myScenario,
+  name = "ecoClassify_RasterOutput")
+
+predictingOutputDataframe <- datasheet(
+  myScenario,
+  name = "ecoClassify_ClassifiedRasterOutput")
+
+
+# Unique timesteps ----------------------------------------------
+
+trainingRasterDataframe <- datasheet(
+  myScenario,
+  name = "ecoClassify_InputTrainingRasters")
+predictingRasterDataframe <- datasheet(
+  myScenario,
+  name = "ecoClassify_InputPredictingRasters")
+
+trainTimestepList <- trainingRasterDataframe %>%
+  filter(!is.na(TrainingRasterFile)) %>%
+  pull(Timesteps) %>%
+  unique()
+predTimestepList <- predictingRasterDataframe %>%
+  filter(!is.na(predictingRasterFile)) %>%
+  pull(Timesteps) %>%
+  unique()
+
+
+
+# Function ---------------------------------------------------------------------
+
+filterRasterDataframe <- function(
+    applyFiltering,
+    predictedPresence,
+    filterResolution,
+    filterPercent,
+    category,
+    timestep,
+    transferDir) {
+  
+  # Filter out presence pixels surrounded by non-presence
+  filteredPredictedPresence <- focal(
+     predictedPresence,
+     w = matrix(1, 5, 5),
+     fun = filterFun,
+     resolution = filterResolution,
+     percent = filterPercent
+  )
+  
+  # File path
+  filteredPath <- file.path(paste0(transferDir,
+                                   "/filteredPredictedPresence-",
+                                   category,
+                                   "-t",
+                                   timestep,
+                                   ".tif"))
+  
+  # Save raster
+  writeRaster(filteredPredictedPresence,
+              filename = filteredPath,
+              overwrite = TRUE)
+ 
+  # Build dataframe
+  rasterDataframe <- data.frame(
+    Timestep = timestep,
+    PredictedFiltered = filteredPath)
+
+  return(rasterDataframe)
+}
+
+# Filter raster ----------------------------------------------------------------
+
+progressBar(type = "message", 
+            message = "Filtering")
+
+# Training step -------------------------------------------------
+
+for(t in trainTimestepList){
+
+  # Get file paths
+  predictedPresenceFilepath <- trainingOutputDataframe$PredictedUnfiltered[
+      trainingOutputDataframe$Timestep == t]
+  
+  if(!is.na(predictedPresenceFilepath)){
+
+    # Load raster
+    predictedPresence <- rast(predictedPresenceFilepath)
+
+    # Filter
+    filteredTraining <- filterRasterDataframe(
+      applyFiltering,
+      predictedPresence,
+      filterResolution,
+      filterPercent,
+      "training",
+      t,
+      transferDir)
+
+    # Combine results
+    trainingOutputDataframe$PredictedFiltered[
+      trainingOutputDataframe$Timestep == t] <- filteredTraining$PredictedFiltered
+  }
+}
+
+# Predicting step -----------------------------------------------
+
+for(t in predTimestepList){
+  
+  # Get file paths
+  classifiedPresenceFilepath <- predictingOutputDataframe$ClassifiedUnfiltered[
+    predictingOutputDataframe$Timestep == t]
+  
+  if(!is.null(classifiedPresenceFilepath)){
+    
+    # Load raster
+    predictedPresence <- rast(classifiedPresenceFilepath)
+    
+    # Filter
+    filteredPredicting <- filterRasterDataframe(
+      applyFiltering,
+      predictedPresence,
+      filterResolution,
+      filterPercent,
+      "predicting",
+      t,
+      transferDir)   
+    
+    # Rename column
+    names(filteredPredicting)[2] <- 
+    
+    # Combine results
+    predictingOutputDataframe$ClassifiedFiltered[
+      predictingOutputDataframe$Timestep == t] <- filteredPredicting$PredictedFiltered
+  }
+}
+
+# Save datasheets back to SyncroSim
+if(dim(trainingOutputDataframe)[1] != 0){
+  saveDatasheet(
+    myScenario,
+    data = trainingOutputDataframe,
+    name = "ecoClassify_RasterOutput"
+  )
+}
+if(dim(predictingOutputDataframe)[1] != 0){
+  saveDatasheet(
+    myScenario,
+    data = predictingOutputDataframe,
+    name = "ecoClassify_ClassifiedRasterOutput"
+  )
+}

--- a/src/functions/0.1-pre-processing.r
+++ b/src/functions/0.1-pre-processing.r
@@ -74,7 +74,6 @@ extractRasters <- function(dataframe, column) {
 #' This function extracts variables from the syncrosim datasheets.
 #' @noRd
 assignVariables <- function(myScenario, trainingRasterDataframe, column) {
-  
   # extract unique timesteps from trainingRasterDataframe
   timestepList <- trainingRasterDataframe %>%
     filter(!is.na(column)) %>%
@@ -132,34 +131,6 @@ assignVariables <- function(myScenario, trainingRasterDataframe, column) {
       type = "info"
     )
   }
-
-  # # Load post-processing options datasheet
-  # postProcessingDataframe <- datasheet(
-  #   myScenario,
-  #   name = "ecoClassify_PostProcessingOptions"
-  # )
-  # 
-  # # Extract post-processing values
-  # filterResolution <- postProcessingDataframe$filterResolution
-  # filterPercent <- postProcessingDataframe$filterPercent
-  # applyFiltering <- postProcessingDataframe$applyFiltering
-
-  # # apply default filtering values if not specified
-  # if (is.na(filterResolution) && applyFiltering == TRUE) {
-  #   filterResolution <- 5
-  #   updateRunLog(
-  #     "Filter resolution was not supplied; using default value of 5",
-  #     type = "info"
-  #   )
-  # }
-  # 
-  # if (is.na(filterPercent) && applyFiltering == TRUE) {
-  #   filterPercent <- 0.25
-  #   updateRunLog(
-  #     "Filter percent was not supplied; using default value of 0.25",
-  #     type = "info"
-  #   )
-  # }
 
   if (setManualThreshold == TRUE) {
     if (
@@ -346,7 +317,6 @@ normalizeRaster <- function(rasterList) {
 #'
 #' @noRd
 checkNA <- function(rasterList) {
-
   for (i in seq_along(rasterList)) {
     raster <- rasterList[[i]]
 

--- a/src/functions/0.1-pre-processing.r
+++ b/src/functions/0.1-pre-processing.r
@@ -86,17 +86,21 @@ assignVariables <- function(myScenario, trainingRasterDataframe, column) {
     myScenario,
     name = "ecoClassify_ClassifierOptions"
   )
+  advClassifierOptionsDataframe <- datasheet(
+    myScenario,
+    name = "ecoClassify_AdvancedClassifierOptions"
+  )
 
   # Extract model input values
   nObs <- classifierOptionsDataframe$nObs
-  applyContextualization <- classifierOptionsDataframe$applyContextualization
-  contextualizationWindowSize <- classifierOptionsDataframe$contextualizationWindowSize
+  applyContextualization <- advClassifierOptionsDataframe$applyContextualization
+  contextualizationWindowSize <- advClassifierOptionsDataframe$contextualizationWindowSize
   modelType <- as.character(classifierOptionsDataframe$modelType)
-  modelTuning <- classifierOptionsDataframe$modelTuning
-  setManualThreshold <- classifierOptionsDataframe$setManualThreshold
-  manualThreshold <- classifierOptionsDataframe$manualThreshold
-  normalizeRasters <- classifierOptionsDataframe$normalizeRasters
-  rasterDecimalPlaces <- classifierOptionsDataframe$rasterDecimalPlaces
+  modelTuning <- advClassifierOptionsDataframe$modelTuning
+  setManualThreshold <- advClassifierOptionsDataframe$setManualThreshold
+  manualThreshold <- advClassifierOptionsDataframe$manualThreshold
+  normalizeRasters <- advClassifierOptionsDataframe$normalizeRasters
+  rasterDecimalPlaces <- advClassifierOptionsDataframe$rasterDecimalPlaces
 
   # assign value of 3 to contextualizationWindowSize if not specified
   if (applyContextualization == TRUE) {
@@ -135,27 +139,27 @@ assignVariables <- function(myScenario, trainingRasterDataframe, column) {
     name = "ecoClassify_PostProcessingOptions"
   )
 
-  # Extract post-processing values
-  filterResolution <- postProcessingDataframe$filterResolution
-  filterPercent <- postProcessingDataframe$filterPercent
-  applyFiltering <- postProcessingDataframe$applyFiltering
+  # # Extract post-processing values
+  # filterResolution <- postProcessingDataframe$filterResolution
+  # filterPercent <- postProcessingDataframe$filterPercent
+  # applyFiltering <- postProcessingDataframe$applyFiltering
 
-  # apply default filtering values if not specified
-  if (is.na(filterResolution) && applyFiltering == TRUE) {
-    filterResolution <- 5
-    updateRunLog(
-      "Filter resolution was not supplied; using default value of 5",
-      type = "info"
-    )
-  }
-
-  if (is.na(filterPercent) && applyFiltering == TRUE) {
-    filterPercent <- 0.25
-    updateRunLog(
-      "Filter percent was not supplied; using default value of 0.25",
-      type = "info"
-    )
-  }
+  # # apply default filtering values if not specified
+  # if (is.na(filterResolution) && applyFiltering == TRUE) {
+  #   filterResolution <- 5
+  #   updateRunLog(
+  #     "Filter resolution was not supplied; using default value of 5",
+  #     type = "info"
+  #   )
+  # }
+  # 
+  # if (is.na(filterPercent) && applyFiltering == TRUE) {
+  #   filterPercent <- 0.25
+  #   updateRunLog(
+  #     "Filter percent was not supplied; using default value of 0.25",
+  #     type = "info"
+  #   )
+  # }
 
   if (setManualThreshold == TRUE) {
     if (
@@ -176,9 +180,9 @@ assignVariables <- function(myScenario, trainingRasterDataframe, column) {
   return(list(
     timestepList,
     nObs,
-    filterResolution,
-    filterPercent,
-    applyFiltering,
+    #filterResolution,
+    #filterPercent,
+    #applyFiltering,
     applyContextualization,
     contextualizationWindowSize,
     modelType,

--- a/src/functions/0.1-pre-processing.r
+++ b/src/functions/0.1-pre-processing.r
@@ -133,12 +133,12 @@ assignVariables <- function(myScenario, trainingRasterDataframe, column) {
     )
   }
 
-  # Load post-processing options datasheet
-  postProcessingDataframe <- datasheet(
-    myScenario,
-    name = "ecoClassify_PostProcessingOptions"
-  )
-
+  # # Load post-processing options datasheet
+  # postProcessingDataframe <- datasheet(
+  #   myScenario,
+  #   name = "ecoClassify_PostProcessingOptions"
+  # )
+  # 
   # # Extract post-processing values
   # filterResolution <- postProcessingDataframe$filterResolution
   # filterPercent <- postProcessingDataframe$filterPercent

--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -331,189 +331,258 @@ reclassifyRaster <- function(raster, threshold) {
 #' Used when preparing outputs for the `ecoClassify_RasterOutput` SyncroSim datasheet.
 #' @noRd
 generateRasterDataframe <- function(
-    applyFiltering,
     predictedPresence,
-    filterResolution,
-    filterPercent,
     category,
     timestep,
     transferDir,
     OutputDataframe,
     hasGroundTruth) {
   if (hasGroundTruth == TRUE) {
-    if (applyFiltering == TRUE) {
-      # filter out presence pixels surrounded by non-presence
-      filteredPredictedPresence <- focal(
-        predictedPresence,
-        w = matrix(1, 5, 5),
-        fun = filterFun,
-        resolution = filterResolution,
-        percent = filterPercent
-      )
-
-      # save raster
-      writeRaster(
-        filteredPredictedPresence,
-        filename = file.path(paste0(
-          transferDir,
-          "/filteredPredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
+    # build dataframe
+    rasterDataframe <- data.frame(
+      Timestep = timestep,
+      PredictedUnfiltered = file.path(paste0(
+        transferDir,
+        "/PredictedPresence-",
+        category,
+        "-t",
+        timestep,
+        ".tif"
         )),
-        overwrite = TRUE
-      )
-
-      # build dataframe
-      rasterDataframe <- data.frame(
-        Timestep = timestep,
-        PredictedUnfiltered = file.path(paste0(
-          transferDir,
-          "/PredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        PredictedFiltered = file.path(paste0(
-          transferDir,
-          "/filteredPredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        GroundTruth = file.path(paste0(
-          transferDir,
-          "/GroundTruth-t",
-          timestep,
-          ".tif"
-        )),
-        Probability = file.path(paste0(
-          transferDir,
-          "/Probability-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        ))
-      )
-    } else {
-      # build dataframe
-      rasterDataframe <- data.frame(
-        Timestep = timestep,
-        PredictedUnfiltered = file.path(paste0(
-          transferDir,
-          "/PredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        PredictedFiltered = "",
-        GroundTruth = file.path(paste0(
-          transferDir,
-          "/GroundTruth-t",
-          timestep,
-          ".tif"
-        )),
-        Probability = file.path(paste0(
-          transferDir,
-          "/Probability-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        ))
-      )
-    }
-
-    # add to output dataframe
-    OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
+      PredictedFiltered = "",
+      GroundTruth = file.path(paste0(
+        transferDir,
+        "/GroundTruth-t",
+        timestep,
+        ".tif"
+      )),
+      Probability = file.path(paste0(
+        transferDir,
+        "/Probability-",
+        category,
+        "-t",
+        timestep,
+        ".tif"
+      ))
+    )
+  # add to output dataframe
+  OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
+  
   } else {
-    if (applyFiltering == TRUE) {
-      # filter out presence pixels surrounded by non-presence
-      filteredPredictedPresence <- focal(
-        predictedPresence,
-        w = matrix(1, 5, 5),
-        fun = filterFun,
-        resolution = filterResolution,
-        percent = filterPercent
-      )
-
-      # save raster
-      writeRaster(
-        filteredPredictedPresence,
-        filename = file.path(paste0(
-          transferDir,
-          "/filteredPredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        overwrite = TRUE
-      )
-
-      # build dataframe
-      rasterDataframe <- data.frame(
-        Timestep = timestep,
-        ClassifiedUnfiltered = file.path(paste0(
-          transferDir,
-          "/PredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        ClassifiedFiltered = file.path(paste0(
-          transferDir,
-          "/filteredPredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        ClassifiedProbability = file.path(paste0(
-          transferDir,
-          "/Probability-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        ))
-      )
-    } else {
-      # build dataframe
-      rasterDataframe <- data.frame(
-        Timestep = timestep,
-        ClassifiedUnfiltered = file.path(paste0(
-          transferDir,
-          "/PredictedPresence-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        )),
-        ClassifiedFiltered = "",
-        ClassifiedProbability = file.path(paste0(
-          transferDir,
-          "/Probability-",
-          category,
-          "-t",
-          timestep,
-          ".tif"
-        ))
-      )
-    }
+  
+    # build dataframe
+    rasterDataframe <- data.frame(
+      Timestep = timestep,
+      ClassifiedUnfiltered = file.path(paste0(
+        transferDir,
+        "/PredictedPresence-",
+        category,
+        "-t",
+        timestep,
+        ".tif"
+      )),
+      ClassifiedFiltered = "",
+      ClassifiedProbability = file.path(paste0(
+        transferDir,
+        "/Probability-",
+        category,
+        "-t",
+        timestep,
+        ".tif"
+      ))
+    )
 
     # add to output dataframe
     OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
+    
   }
-
+  
   return(OutputDataframe)
 }
+# generateRasterDataframe <- function(
+#     applyFiltering,
+#     predictedPresence,
+#     filterResolution,
+#     filterPercent,
+#     category,
+#     timestep,
+#     transferDir,
+#     OutputDataframe,
+#     hasGroundTruth) {
+#   if (hasGroundTruth == TRUE) {
+#     if (applyFiltering == TRUE) {
+#       # filter out presence pixels surrounded by non-presence
+#       filteredPredictedPresence <- focal(
+#         predictedPresence,
+#         w = matrix(1, 5, 5),
+#         fun = filterFun,
+#         resolution = filterResolution,
+#         percent = filterPercent
+#       )
+#       
+#       # save raster
+#       writeRaster(
+#         filteredPredictedPresence,
+#         filename = file.path(paste0(
+#           transferDir,
+#           "/filteredPredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         overwrite = TRUE
+#       )
+#       
+#       # build dataframe
+#       rasterDataframe <- data.frame(
+#         Timestep = timestep,
+#         PredictedUnfiltered = file.path(paste0(
+#           transferDir,
+#           "/PredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         PredictedFiltered = file.path(paste0(
+#           transferDir,
+#           "/filteredPredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         GroundTruth = file.path(paste0(
+#           transferDir,
+#           "/GroundTruth-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         Probability = file.path(paste0(
+#           transferDir,
+#           "/Probability-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         ))
+#       )
+#     } else {
+#       # build dataframe
+#       rasterDataframe <- data.frame(
+#         Timestep = timestep,
+#         PredictedUnfiltered = file.path(paste0(
+#           transferDir,
+#           "/PredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         PredictedFiltered = "",
+#         GroundTruth = file.path(paste0(
+#           transferDir,
+#           "/GroundTruth-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         Probability = file.path(paste0(
+#           transferDir,
+#           "/Probability-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         ))
+#       )
+#     }
+#     
+#     # add to output dataframe
+#     OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
+#   } else {
+#     if (applyFiltering == TRUE) {
+#       # filter out presence pixels surrounded by non-presence
+#       filteredPredictedPresence <- focal(
+#         predictedPresence,
+#         w = matrix(1, 5, 5),
+#         fun = filterFun,
+#         resolution = filterResolution,
+#         percent = filterPercent
+#       )
+#       
+#       # save raster
+#       writeRaster(
+#         filteredPredictedPresence,
+#         filename = file.path(paste0(
+#           transferDir,
+#           "/filteredPredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         overwrite = TRUE
+#       )
+#       
+#       # build dataframe
+#       rasterDataframe <- data.frame(
+#         Timestep = timestep,
+#         ClassifiedUnfiltered = file.path(paste0(
+#           transferDir,
+#           "/PredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         ClassifiedFiltered = file.path(paste0(
+#           transferDir,
+#           "/filteredPredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         ClassifiedProbability = file.path(paste0(
+#           transferDir,
+#           "/Probability-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         ))
+#       )
+#     } else {
+#       # build dataframe
+#       rasterDataframe <- data.frame(
+#         Timestep = timestep,
+#         ClassifiedUnfiltered = file.path(paste0(
+#           transferDir,
+#           "/PredictedPresence-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         )),
+#         ClassifiedFiltered = "",
+#         ClassifiedProbability = file.path(paste0(
+#           transferDir,
+#           "/Probability-",
+#           category,
+#           "-t",
+#           timestep,
+#           ".tif"
+#         ))
+#       )
+#     }
+#     
+#     # add to output dataframe
+#     OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
+#   }
+#   
+#   return(OutputDataframe)
+# }
 
 #' Append RGB image path to output dataframe ---
 #'

--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -34,11 +34,11 @@
 #'
 #' @noRd
 splitTrainTest <- function(
-    trainingRasterList,
-    groundTruthRasterList,
-    nObs,
-    nBlocks = 25,
-    proportionTraining = 0.8
+  trainingRasterList,
+  groundTruthRasterList,
+  nObs,
+  nBlocks = 25,
+  proportionTraining = 0.8
 ) {
   blockDim <- sqrt(nBlocks)
   if (blockDim != floor(blockDim)) {
@@ -84,7 +84,11 @@ splitTrainTest <- function(
 
   # Extract block ID and presence values
   block_vals <- terra::extract(block_raster, vect(sampled_sf), df = TRUE)[, 2]
-  presence_vals <- terra::extract(groundTruthRasterList[[1]], vect(sampled_sf), df = TRUE)[, 2]
+  presence_vals <- terra::extract(
+    groundTruthRasterList[[1]],
+    vect(sampled_sf),
+    df = TRUE
+  )[, 2]
 
   # Combine into sf object
   ptsSf <- sampled_sf
@@ -105,7 +109,11 @@ splitTrainTest <- function(
     slice_sample(prop = proportionTraining) %>%
     ungroup()
 
-  testPts <- anti_join(ptsSf, st_drop_geometry(trainPts), by = colnames(trainPts)[!colnames(trainPts) %in% c("geometry")])
+  testPts <- anti_join(
+    ptsSf,
+    st_drop_geometry(trainPts),
+    by = colnames(trainPts)[!colnames(trainPts) %in% c("geometry")]
+  )
 
   # Extract predictors at each time step
   extract_at_pts <- function(rStack, pts) {
@@ -115,27 +123,49 @@ splitTrainTest <- function(
   train_list <- lapply(trainingRasterList, extract_at_pts, pts = trainPts)
   test_list <- lapply(trainingRasterList, extract_at_pts, pts = testPts)
 
-  train_df <- do.call(rbind, lapply(train_list, function(df) cbind(df, presence = trainPts$presence)))
-  test_df <- do.call(rbind, lapply(test_list, function(df) cbind(df, presence = testPts$presence)))
+  train_df <- do.call(
+    rbind,
+    lapply(train_list, function(df) cbind(df, presence = trainPts$presence))
+  )
+  test_df <- do.call(
+    rbind,
+    lapply(test_list, function(df) cbind(df, presence = testPts$presence))
+  )
 
   # Drop NA rows
   n_train_before <- nrow(train_df)
   train_df <- train_df[complete.cases(train_df), ]
   if ((n_train_before - nrow(train_df)) > 0) {
-    updateRunLog(sprintf("%d rows dropped from training data due to NA values.", n_train_before - nrow(train_df)), type = "warning")
+    updateRunLog(
+      sprintf(
+        "%d rows dropped from training data due to NA values.",
+        n_train_before - nrow(train_df)
+      ),
+      type = "warning"
+    )
   }
 
   n_test_before <- nrow(test_df)
   test_df <- test_df[complete.cases(test_df), ]
   if ((n_test_before - nrow(test_df)) > 0) {
-    updateRunLog(sprintf("%d rows dropped from testing data due to NA values.", n_test_before - nrow(test_df)), type = "warning")
+    updateRunLog(
+      sprintf(
+        "%d rows dropped from testing data due to NA values.",
+        n_test_before - nrow(test_df)
+      ),
+      type = "warning"
+    )
   }
 
   if (nrow(train_df) < 2) {
-    stop("Insufficient training data (< 2 rows). Check presence balance or NA filtering.")
+    stop(
+      "Insufficient training data (< 2 rows). Check presence balance or NA filtering."
+    )
   }
   if (length(unique(train_df$presence)) < 2) {
-    stop("Training data must include at least one presence (1) and one absence (0).")
+    stop(
+      "Training data must include at least one presence (1) and one absence (0)."
+    )
   }
 
   return(list(train = train_df, test = test_df))
@@ -180,9 +210,10 @@ getSensSpec <- function(probs, actual, threshold) {
 #'
 #' @noRd
 getOptimalThreshold <- function(
-    model,
-    testingData,
-    modelType) {
+  model,
+  testingData,
+  modelType
+) {
   # define thresholds
   thresholds <- seq(0.01, 0.99, by = 0.01)
 
@@ -256,11 +287,11 @@ getOptimalThreshold <- function(
 #' This function is commonly used when generating per-timestep prediction maps across a study area.
 #' @noRd
 getPredictionRasters <- function(
-    raster,
-    model,
-    threshold,
-    modelType = "Random Forest") {
-
+  raster,
+  model,
+  threshold,
+  modelType = "Random Forest"
+) {
   # predict presence for each raster
   if (modelType == "Random Forest") {
     # generate probabilities for each raster using ranger
@@ -331,12 +362,13 @@ reclassifyRaster <- function(raster, threshold) {
 #' Used when preparing outputs for the `ecoClassify_RasterOutput` SyncroSim datasheet.
 #' @noRd
 generateRasterDataframe <- function(
-    predictedPresence,
-    category,
-    timestep,
-    transferDir,
-    OutputDataframe,
-    hasGroundTruth) {
+  predictedPresence,
+  category,
+  timestep,
+  transferDir,
+  OutputDataframe,
+  hasGroundTruth
+) {
   if (hasGroundTruth == TRUE) {
     # build dataframe
     rasterDataframe <- data.frame(
@@ -348,7 +380,7 @@ generateRasterDataframe <- function(
         "-t",
         timestep,
         ".tif"
-        )),
+      )),
       PredictedFiltered = "",
       GroundTruth = file.path(paste0(
         transferDir,
@@ -365,11 +397,9 @@ generateRasterDataframe <- function(
         ".tif"
       ))
     )
-  # add to output dataframe
-  OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
-  
+    # add to output dataframe
+    OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
   } else {
-  
     # build dataframe
     rasterDataframe <- data.frame(
       Timestep = timestep,
@@ -394,195 +424,11 @@ generateRasterDataframe <- function(
 
     # add to output dataframe
     OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
-    
   }
-  
+
   return(OutputDataframe)
 }
-# generateRasterDataframe <- function(
-#     applyFiltering,
-#     predictedPresence,
-#     filterResolution,
-#     filterPercent,
-#     category,
-#     timestep,
-#     transferDir,
-#     OutputDataframe,
-#     hasGroundTruth) {
-#   if (hasGroundTruth == TRUE) {
-#     if (applyFiltering == TRUE) {
-#       # filter out presence pixels surrounded by non-presence
-#       filteredPredictedPresence <- focal(
-#         predictedPresence,
-#         w = matrix(1, 5, 5),
-#         fun = filterFun,
-#         resolution = filterResolution,
-#         percent = filterPercent
-#       )
-#       
-#       # save raster
-#       writeRaster(
-#         filteredPredictedPresence,
-#         filename = file.path(paste0(
-#           transferDir,
-#           "/filteredPredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         overwrite = TRUE
-#       )
-#       
-#       # build dataframe
-#       rasterDataframe <- data.frame(
-#         Timestep = timestep,
-#         PredictedUnfiltered = file.path(paste0(
-#           transferDir,
-#           "/PredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         PredictedFiltered = file.path(paste0(
-#           transferDir,
-#           "/filteredPredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         GroundTruth = file.path(paste0(
-#           transferDir,
-#           "/GroundTruth-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         Probability = file.path(paste0(
-#           transferDir,
-#           "/Probability-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         ))
-#       )
-#     } else {
-#       # build dataframe
-#       rasterDataframe <- data.frame(
-#         Timestep = timestep,
-#         PredictedUnfiltered = file.path(paste0(
-#           transferDir,
-#           "/PredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         PredictedFiltered = "",
-#         GroundTruth = file.path(paste0(
-#           transferDir,
-#           "/GroundTruth-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         Probability = file.path(paste0(
-#           transferDir,
-#           "/Probability-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         ))
-#       )
-#     }
-#     
-#     # add to output dataframe
-#     OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
-#   } else {
-#     if (applyFiltering == TRUE) {
-#       # filter out presence pixels surrounded by non-presence
-#       filteredPredictedPresence <- focal(
-#         predictedPresence,
-#         w = matrix(1, 5, 5),
-#         fun = filterFun,
-#         resolution = filterResolution,
-#         percent = filterPercent
-#       )
-#       
-#       # save raster
-#       writeRaster(
-#         filteredPredictedPresence,
-#         filename = file.path(paste0(
-#           transferDir,
-#           "/filteredPredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         overwrite = TRUE
-#       )
-#       
-#       # build dataframe
-#       rasterDataframe <- data.frame(
-#         Timestep = timestep,
-#         ClassifiedUnfiltered = file.path(paste0(
-#           transferDir,
-#           "/PredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         ClassifiedFiltered = file.path(paste0(
-#           transferDir,
-#           "/filteredPredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         ClassifiedProbability = file.path(paste0(
-#           transferDir,
-#           "/Probability-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         ))
-#       )
-#     } else {
-#       # build dataframe
-#       rasterDataframe <- data.frame(
-#         Timestep = timestep,
-#         ClassifiedUnfiltered = file.path(paste0(
-#           transferDir,
-#           "/PredictedPresence-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         )),
-#         ClassifiedFiltered = "",
-#         ClassifiedProbability = file.path(paste0(
-#           transferDir,
-#           "/Probability-",
-#           category,
-#           "-t",
-#           timestep,
-#           ".tif"
-#         ))
-#       )
-#     }
-#     
-#     # add to output dataframe
-#     OutputDataframe <- addRow(OutputDataframe, rasterDataframe)
-#   }
-#   
-#   return(OutputDataframe)
-# }
+
 
 #' Append RGB image path to output dataframe ---
 #'
@@ -608,10 +454,11 @@ generateRasterDataframe <- function(
 #' visual inspection of RGB representations of predictor data at each timestep.
 #' @noRd
 getRgbDataframe <- function(
-    rgbOutputDataframe,
-    category,
-    timestep,
-    transferDir) {
+  rgbOutputDataframe,
+  category,
+  timestep,
+  transferDir
+) {
   rgbDataframe <- data.frame(
     Timestep = timestep,
     RGBImage = file.path(paste0(
@@ -659,13 +506,14 @@ getRgbDataframe <- function(
 #' from the training raster and saved as `RGBImage-{category}-t{timestep}.png`.
 #' @noRd
 saveFiles <- function(
-    predictedPresence,
-    groundTruth = NULL,
-    probabilityRaster,
-    trainingRasterList,
-    category,
-    timestep,
-    transferDir) {
+  predictedPresence,
+  groundTruth = NULL,
+  probabilityRaster,
+  trainingRasterList,
+  category,
+  timestep,
+  transferDir
+) {
   # save rasters
   writeRaster(
     predictedPresence,

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <package 
-    name="ecoClassify" displayName="ecoClassify" version="1.2.2"
+    name="ecoClassify" displayName="ecoClassify" version="2.0.0"
     description="Image classifier using semantic image segmentation" 
     url="https://apexrms.github.io/ecoClassify/" 
     minSyncroSimVersion="3.1.0">

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <package 
-    name="ecoClassify" displayName="ecoClassify" version="2.0.0"
+    name="ecoClassify" displayName="ecoClassify" version="1.2.2"
     description="Image classifier using semantic image segmentation" 
     url="https://apexrms.github.io/ecoClassify/" 
     minSyncroSimVersion="3.1.0">
@@ -54,12 +54,6 @@
         <record columns="normalizeRasters|modelTuning|setManualThreshold|applyContextualization" values="0|0|0|0"/>
     </dataSheet>
     
-    <dataSheet name="PostProcessingOptions" displayName="Post-processing options" isSingleRow="True">
-        <column name="applyFiltering" dataType="Boolean" displayName="Apply Filtering"/>
-        <column name="filterResolution" dataType="Double" displayName="Filter Resolution"/>
-        <column name="filterPercent" dataType="Double" displayName="Filter Threshold"/>
-    </dataSheet>
-
     <dataSheet name="PostProcessingFilter" displayName="Filtering" isSingleRow="True">
         <column name="applyFiltering" dataType="Boolean" displayName="Apply Filtering"/>
         <column name="filterResolution" dataType="Double" displayName="Filter Resolution"/>
@@ -71,12 +65,13 @@
         <column name="ruleRasterFile" dataType="String" displayName="Condition Raster" isExternalFile="True"/>
         <column name="ruleMinValue" dataType="Double" displayName="Minimum Value"/>
         <column name="ruleMaxValue" dataType="Double" displayName="Maximum Value"/>
-        <column name="ruleReclassValue" dataType="Integer" displayName="Reclassify Value"/>
+        <column name="ruleReclassValue" dataType="Integer" displayName="Reclassify Value" validationType="List" formula1="0:0|1:1"/>
     </dataSheet>
 
     <!--Output-->
     <dataSheet name="RasterOutput" displayName="Training Rasters" hasTimestep="True">
         <column name="PredictedUnfiltered" dataType="String" displayName="Predicted" isExternalFile="True" isRaster="True" bandColumn="Band"/>
+        <column name="PredictedUnfilteredRestricted" dataType="String" displayName="Predicted Restricted" isExternalFile="True" isRaster="True" bandColumn="Band"/>
         <column name="PredictedFiltered" dataType="String" displayName="Predicted Filtered" isExternalFile="True" isRaster="True" bandColumn="Band"/>
         <column name="GroundTruth" dataType="String" displayName="User Classification" isExternalFile="True" isRaster="True"/>
         <column name="Probability" dataType="String" displayName="Probability" isExternalFile="True" isRaster="True"/>
@@ -85,6 +80,7 @@
 
     <dataSheet name="ClassifiedRasterOutput" displayName="Classified Rasters" hasTimestep="True">
         <column name="ClassifiedUnfiltered" dataType="String" displayName="Classified" isExternalFile="True" isRaster="True" bandColumn="Band"/>
+        <column name="ClassifiedUnfilteredRestricted" dataType="String" displayName="Classified Restricted" isExternalFile="True" isRaster="True" bandColumn="Band"/>
         <column name="ClassifiedFiltered" dataType="String" displayName="Classified Filtered" isExternalFile="True" isRaster="True" bandColumn="Band"/>
         <column name="ClassifiedProbability" dataType="String" displayName="Probability" isExternalFile="True" isRaster="True"/>
         <column name="Band" displayName="Band" dataType="Integer" allowDbNull="True" isOptional="True"/>
@@ -173,7 +169,6 @@
     <transformer name="PostProcessing" displayName="3-Post-Process" programName="Rscript" programArguments="3-postprocess.R" condaEnv="ecoClassify-conda.yml" condaEnvVersion="1.3">
         <dataSheet name="RasterOutput" type="Both"/>
         <dataSheet name="ClassifiedRasterOutput" type="Both"/>
-        <dataSheet name="PostProcessingOptions" type="Input"/>
         <dataSheet name="PostProcessingFilter" type="Input"/>
         <dataSheet name="PostProcessingRule" type="Input"/>
         <dataSheet name="InputTrainingRasters" type="Input"/>
@@ -184,6 +179,7 @@
     <transformer name="ConfusionMatrixExport" dataSheet="ConfusionMatrix" isExport="True"/>
     <transformer name="ModelStatisticsExport" dataSheet="ModelStatistics" isExport="True"/>
     <transformer name="PredictedUnfilteredExport" dataSheet="RasterOutput" column="PredictedUnfiltered" isRasterExport="True"/>
+    <transformer name="PredictedUnfilteredRestrictedExport" dataSheet="RasterOutput" column="PredictedUnfilteredRestricted" isRasterExport="True"/>
     <transformer name="PredictedFilteredExport" dataSheet="RasterOutput" column="PredictedFiltered" isRasterExport="True"/>
     <transformer name="ProbabilityExport" dataSheet="RasterOutput" column="Probability" isRasterExport="True"/>
     <transformer name="GroundTruthExport" dataSheet="RasterOutput" column="GroundTruth" isRasterExport="True"/>
@@ -194,6 +190,7 @@
     <transformer name="RgbOutputExport" dataSheet="RgbOutput" column="RGBImage" isExport="True"/>
     <transformer name="ClassifiedRgbOutputExport" dataSheet="ClassifiedRgbOutput" column="RGBImage" isExport="True"/>
     <transformer name="ClassifiedUnfilteredExport" dataSheet="ClassifiedRasterOutput" column="ClassifiedUnfiltered" isRasterExport="True"/>
+    <transformer name="ClassifiedUnfilteredRestrictedExport" dataSheet="ClassifiedRasterOutput" column="ClassifiedUnfilteredRestricted" isRasterExport="True"/>
     <transformer name="ClassifiedFilteredExport" dataSheet="ClassifiedRasterOutput" column="ClassifiedFiltered" isRasterExport="True"/>
     <transformer name="ClassifiedProbabilityExport" dataSheet="ClassifiedRasterOutput" column="ClassifiedProbability" isRasterExport="True"/>
 
@@ -214,7 +211,6 @@
             </group>
             <item name="AdvancedClassifierOptions"/>
             <group name="PostProcessingOptions" displayName="Post-Processing Options">
-                <item name="PostProcessingOptions"/>
                 <item name="PostProcessingFilter"/>
                 <item name="PostProcessingRule"/>
             </group>
@@ -241,12 +237,14 @@
 	<layout type="Map">
         <group name="PredictionMaps" displayName="Training Predictions">
 		    <item name="PredictedUnfilteredMap" displayName="Unfiltered" dataSheet="RasterOutput" column="PredictedUnfiltered"/>
+            <item name="PredictedUnfilteredRestrictedMap" displayName="Unfiltered Restricted" dataSheet="RasterOutput" column="PredictedUnfilteredRestricted"/>
             <item name="PredictedFilteredMap" displayName="Filtered" dataSheet="RasterOutput" column="PredictedFiltered"/>
             <item name="ProbabilityMap" displayName="Probability" dataSheet="RasterOutput" column="Probability"/>
             <item name="GroundTruthMap" displayName="User Classification" dataSheet="RasterOutput" column="GroundTruth"/>
         </group>
         <group name="ClassifiedPredictionMaps" displayName="Predictions">
 		    <item name="ClassifiedUnfilteredMap" displayName="Unfiltered" dataSheet="ClassifiedRasterOutput" column="ClassifiedUnfiltered"/>
+            <item name="ClassifiedUnfilteredRestrictedMap" displayName="Unfiltered Restricted" dataSheet="ClassifiedRasterOutput" column="ClassifiedUnfilteredRestricted"/>
             <item name="ClassifiedFilteredMap" displayName="Filtered" dataSheet="ClassifiedRasterOutput" column="ClassifiedFiltered"/>
             <item name="ClassifiedProbabilityMap" displayName="Probability" dataSheet="ClassifiedRasterOutput" column="ClassifiedProbability"/>
         </group>
@@ -273,12 +271,14 @@
         <group name="MapExport" displayName="Map Outputs">
             <group name="TrainingMapExport" displayName="Training">
                 <item name="PredictedUnfilteredExport" displayName="Unfiltered Prediction"/>
+                <item name="PredictedUnfilteredRestrictedExport" displayName="Unfiltered Restricted Prediction"/>
                 <item name="PredictedFilteredExport" displayName="Filtered Prediction"/>
                 <item name="ProbabilityExport" displayName="Probability"/>
                 <item name="GroundTruthExport" displayName="User Classification"/>
             </group>
             <group name="PredictingMapExport" displayName="Prediction">
                 <item name="ClassifiedUnfilteredExport" displayName="Unfiltered Prediction"/>
+                <item name="ClassifiedUnfilteredRestrictedExport" displayName="Unfiltered Restricted Prediction"/>
                 <item name="ClassifiedFilteredExport" displayName="Filtered Prediction"/>
                 <item name="ClassifiedProbabilityExport" displayName="Probability"/>
             </group>

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package name="ecoClassify" displayName="ecoClassify" description="Image classifier using semantic image segmentation" version="1.2.2" url="https://apexrms.github.io/ecoClassify/" minSyncroSimVersion="3.1.0">
+
+<package 
+    name="ecoClassify" displayName="ecoClassify" version="2.0.0"
+    description="Image classifier using semantic image segmentation" 
+    url="https://apexrms.github.io/ecoClassify/" 
+    minSyncroSimVersion="3.1.0">
 
     <!--Project Level-->
     <dataSheet name="Terminology" isSingleRow="True" dataScope="Project">
@@ -13,7 +18,7 @@
     <dataSheet name="InputTrainingRasters" displayName="Training Rasters">
         <column name="Timesteps" dataType="Integer" displayName="Timestep"/>
         <column name="TrainingRasterFile" dataType="String" displayName="Training Raster" isExternalFile="True"/>
-        <column name="GroundTruthRasterFile" dataType="String" displayName="Ground Truth Raster" isExternalFile="True"/>
+        <column name="GroundTruthRasterFile" dataType="String" displayName="User Classified Raster" isExternalFile="True"/>
     </dataSheet>
 
     <dataSheet name="InputPredictingRasters" displayName="Predicting Rasters">
@@ -24,7 +29,6 @@
     <dataSheet name="InputTrainingCovariates" displayName="Covariates">
         <column name="trainingCovariateRasterFile" dataType="String" displayName="Covariate Raster" isExternalFile="True"/>
         <column name="trainingCovariateType" displayName="Data Type" dataType="Integer" validationType="List" formula1="0:Categorical|1:Continuous"/>
-
     </dataSheet>
 
     <dataSheet name="InputPredictingCovariates" displayName="Covariates">
@@ -34,28 +38,47 @@
 
     <dataSheet name="ClassifierOptions" displayName="Classifier Options" isSingleRow="True">
         <column name="nObs" dataType="Integer" displayName="Sample Size"/>
+        <column name="modelType" displayName="Model Type" dataType="Integer" validationType="List" formula1="0:Random Forest|1:MaxEnt|2:CNN"/>
+        <record columns="nObs|modelType" values="10000|0"/>
+    </dataSheet>
+
+    <dataSheet name="AdvancedClassifierOptions" displayName="Advanced" isSingleRow="True">
         <column name="normalizeRasters" dataType="Boolean" displayName="Normalize Rasters"/>
         <column name="rasterDecimalPlaces" displayName="Raster Decimal Places (Rounding)" dataType="Integer" isOptional="True"/>
-        <column name="modelType" displayName="Model Type" dataType="Integer" validationType="List" formula1="0:Random Forest|1:MaxEnt|2:CNN"/>
         <column name="modelTuning" displayName="Enable Automated Tuning" dataType="Boolean"/>
         <column name="setManualThreshold" displayName="Set Probability Threshold" dataType="Boolean"/>
         <column name="manualThreshold" displayName="Probability Threshold" dataType="Double" isOptional="True"/>
         <column name="applyContextualization" dataType="Boolean" displayName="Apply Contextualization"/>
         <column name="contextualizationWindowSize" dataType="Integer" displayName="Contextualization Window Size" isOptional="True"/>
-         <column name="setSeed" dataType="Integer" displayName="Random Seed" isOptional="True"/>
+        <column name="setSeed" dataType="Integer" displayName="Random Seed" isOptional="True"/>
+        <record columns="normalizeRasters|modelTuning|setManualThreshold|applyContextualization" values="0|0|0|0"/>
     </dataSheet>
-
+    
     <dataSheet name="PostProcessingOptions" displayName="Post-processing options" isSingleRow="True">
         <column name="applyFiltering" dataType="Boolean" displayName="Apply Filtering"/>
         <column name="filterResolution" dataType="Double" displayName="Filter Resolution"/>
         <column name="filterPercent" dataType="Double" displayName="Filter Threshold"/>
     </dataSheet>
 
+    <dataSheet name="PostProcessingFilter" displayName="Filtering" isSingleRow="True">
+        <column name="applyFiltering" dataType="Boolean" displayName="Apply Filtering"/>
+        <column name="filterResolution" dataType="Double" displayName="Filter Resolution"/>
+        <column name="filterPercent" dataType="Double" displayName="Filter Threshold"/>
+    </dataSheet>
+
+    <dataSheet name="PostProcessingRule" displayName="Rule-Based Restrictions" isSingleRow="False">
+        <column name="ruleClass" dataType="Integer" displayName="Class"/>
+        <column name="ruleRasterFile" dataType="String" displayName="Condition Raster" isExternalFile="True"/>
+        <column name="ruleMinValue" dataType="Double" displayName="Minimum Value"/>
+        <column name="ruleMaxValue" dataType="Double" displayName="Maximum Value"/>
+        <column name="ruleReclassValue" dataType="Integer" displayName="Reclassify Value"/>
+    </dataSheet>
+
     <!--Output-->
     <dataSheet name="RasterOutput" displayName="Training Rasters" hasTimestep="True">
         <column name="PredictedUnfiltered" dataType="String" displayName="Predicted" isExternalFile="True" isRaster="True" bandColumn="Band"/>
         <column name="PredictedFiltered" dataType="String" displayName="Predicted Filtered" isExternalFile="True" isRaster="True" bandColumn="Band"/>
-        <column name="GroundTruth" dataType="String" displayName="Ground Truth" isExternalFile="True" isRaster="True"/>
+        <column name="GroundTruth" dataType="String" displayName="User Classification" isExternalFile="True" isRaster="True"/>
         <column name="Probability" dataType="String" displayName="Probability" isExternalFile="True" isRaster="True"/>
         <column name="Band" displayName="Band" dataType="Integer" allowDbNull="True" isOptional="True"/>
     </dataSheet>
@@ -123,7 +146,7 @@
         <dataSheet name="InputPredictingRasters" type="Input"/>
         <dataSheet name="InputTrainingCovariates" type="Input"/>
         <dataSheet name="ClassifierOptions" type="Input"/>
-        <dataSheet name="PostProcessingOptions" type="Input"/>
+        <dataSheet name="AdvancedClassifierOptions" type="Input"/>
         <dataSheet name="RasterOutput" type="Output"/>
         <dataSheet name="ConfusionMatrix" type="Output"/>
         <dataSheet name="ModelStatistics" type="Output"/>
@@ -140,10 +163,21 @@
         <dataSheet name="InputPredictingRasters" type="Input"/>
         <dataSheet name="InputPredictingCovariates" type="Input"/>
         <dataSheet name="ClassifierOptions" type="Input"/>
-        <dataSheet name="PostProcessingOptions" type="Input"/>
+        <dataSheet name="AdvancedClassifierOptions" type="Input"/>
         <dataSheet name="ModelObject" type="Input"/>
         <dataSheet name="ClassifiedRasterOutput" type="Output"/>
         <dataSheet name="ClassifiedRgbOutput" type="Output"/>
+    </transformer>
+
+    <!--Transformer 3: filtering-->
+    <transformer name="PostProcessing" displayName="3-Post-Process" programName="Rscript" programArguments="3-postprocess.R" condaEnv="ecoClassify-conda.yml" condaEnvVersion="1.3">
+        <dataSheet name="RasterOutput" type="Both"/>
+        <dataSheet name="ClassifiedRasterOutput" type="Both"/>
+        <dataSheet name="PostProcessingOptions" type="Input"/>
+        <dataSheet name="PostProcessingFilter" type="Input"/>
+        <dataSheet name="PostProcessingRule" type="Input"/>
+        <dataSheet name="InputTrainingRasters" type="Input"/>
+        <dataSheet name="InputPredictingRasters" type="Input"/>
     </transformer>
 
     <!--Export transformers-->
@@ -168,7 +202,6 @@
 
         <group name="AllInputs" displayName="Input">
             <item name="ClassifierOptions"/>
-            <item name="PostProcessingOptions"/>
             <group name="InputRasters" displayName="Rasters">
                 <group name="trainingRasters" displayName="Training">
                     <item name="InputTrainingRasters"/>
@@ -178,6 +211,12 @@
                     <item name="InputPredictingRasters"/>
                     <item name="InputPredictingCovariates"/>
                 </group>
+            </group>
+            <item name="AdvancedClassifierOptions"/>
+            <group name="PostProcessingOptions" displayName="Post-Processing Options">
+                <item name="PostProcessingOptions"/>
+                <item name="PostProcessingFilter"/>
+                <item name="PostProcessingRule"/>
             </group>
         </group>
 
@@ -204,7 +243,7 @@
 		    <item name="PredictedUnfilteredMap" displayName="Unfiltered" dataSheet="RasterOutput" column="PredictedUnfiltered"/>
             <item name="PredictedFilteredMap" displayName="Filtered" dataSheet="RasterOutput" column="PredictedFiltered"/>
             <item name="ProbabilityMap" displayName="Probability" dataSheet="RasterOutput" column="Probability"/>
-            <item name="GroundTruthMap" displayName="Ground Truth" dataSheet="RasterOutput" column="GroundTruth"/>
+            <item name="GroundTruthMap" displayName="User Classification" dataSheet="RasterOutput" column="GroundTruth"/>
         </group>
         <group name="ClassifiedPredictionMaps" displayName="Predictions">
 		    <item name="ClassifiedUnfilteredMap" displayName="Unfiltered" dataSheet="ClassifiedRasterOutput" column="ClassifiedUnfiltered"/>
@@ -236,7 +275,7 @@
                 <item name="PredictedUnfilteredExport" displayName="Unfiltered Prediction"/>
                 <item name="PredictedFilteredExport" displayName="Filtered Prediction"/>
                 <item name="ProbabilityExport" displayName="Probability"/>
-                <item name="GroundTruthExport" displayName="Ground Truth"/>
+                <item name="GroundTruthExport" displayName="User Classification"/>
             </group>
             <group name="PredictingMapExport" displayName="Prediction">
                 <item name="ClassifiedUnfilteredExport" displayName="Unfiltered Prediction"/>

--- a/src/package.xml
+++ b/src/package.xml
@@ -8,8 +8,8 @@
 
     <!--Project Level-->
     <dataSheet name="Terminology" isSingleRow="True" dataScope="Project">
-        <column name="bandNames" dataType="String" displayName="Training Raster Band Names" isExternalFile="True"/>
-        <column name="timestepName" dataType="String" displayName="Raster Group Name"/>
+        <column name="bandNames" dataType="String" displayName="Training raster band names" isExternalFile="True"/>
+        <column name="timestepName" dataType="String" displayName="Raster group name"/>
         <record columns="timestepName" values="Timestep"/>
     </dataSheet>
 
@@ -37,30 +37,30 @@
     </dataSheet>
 
     <dataSheet name="ClassifierOptions" displayName="Classifier Options" isSingleRow="True">
-        <column name="nObs" dataType="Integer" displayName="Sample Size"/>
-        <column name="modelType" displayName="Model Type" dataType="Integer" validationType="List" formula1="0:Random Forest|1:MaxEnt|2:CNN"/>
+        <column name="nObs" dataType="Integer" displayName="Sample size"/>
+        <column name="modelType" displayName="Model type" dataType="Integer" validationType="List" formula1="0:Random Forest|1:MaxEnt|2:CNN"/>
         <record columns="nObs|modelType" values="10000|0"/>
     </dataSheet>
 
     <dataSheet name="AdvancedClassifierOptions" displayName="Advanced" isSingleRow="True">
-        <column name="normalizeRasters" dataType="Boolean" displayName="Normalize Rasters"/>
-        <column name="rasterDecimalPlaces" displayName="Raster Decimal Places (Rounding)" dataType="Integer" isOptional="True"/>
-        <column name="modelTuning" displayName="Enable Automated Tuning" dataType="Boolean"/>
-        <column name="setManualThreshold" displayName="Set Probability Threshold" dataType="Boolean"/>
-        <column name="manualThreshold" displayName="Probability Threshold" dataType="Double" isOptional="True"/>
-        <column name="applyContextualization" dataType="Boolean" displayName="Apply Contextualization"/>
-        <column name="contextualizationWindowSize" dataType="Integer" displayName="Contextualization Window Size" isOptional="True"/>
-        <column name="setSeed" dataType="Integer" displayName="Random Seed" isOptional="True"/>
+        <column name="normalizeRasters" dataType="Boolean" displayName="Normalize rasters"/>
+        <column name="rasterDecimalPlaces" displayName="Raster decimal places (rounding)" dataType="Integer" isOptional="True"/>
+        <column name="modelTuning" displayName="Enable automated tuning" dataType="Boolean"/>
+        <column name="setManualThreshold" displayName="Set probability threshold" dataType="Boolean"/>
+        <column name="manualThreshold" displayName="Probability threshold" dataType="Double" isOptional="True"/>
+        <column name="applyContextualization" dataType="Boolean" displayName="Apply contextualization"/>
+        <column name="contextualizationWindowSize" dataType="Integer" displayName="Contextualization window size" isOptional="True"/>
+        <column name="setSeed" dataType="Integer" displayName="Random seed" isOptional="True"/>
         <record columns="normalizeRasters|modelTuning|setManualThreshold|applyContextualization" values="0|0|0|0"/>
     </dataSheet>
     
     <dataSheet name="PostProcessingFilter" displayName="Filtering" isSingleRow="True">
-        <column name="applyFiltering" dataType="Boolean" displayName="Apply Filtering"/>
-        <column name="filterResolution" dataType="Double" displayName="Filter Resolution"/>
-        <column name="filterPercent" dataType="Double" displayName="Filter Threshold"/>
+        <column name="applyFiltering" dataType="Boolean" displayName="Apply filtering"/>
+        <column name="filterResolution" dataType="Double" displayName="Filter resolution"/>
+        <column name="filterPercent" dataType="Double" displayName="Filter threshold"/>
     </dataSheet>
 
-    <dataSheet name="PostProcessingRule" displayName="Rule-Based Restrictions" isSingleRow="False">
+    <dataSheet name="PostProcessingRule" displayName="Rule-Based Restrictions">
         <column name="ruleClass" dataType="Integer" displayName="Class"/>
         <column name="ruleRasterFile" dataType="String" displayName="Condition Raster" isExternalFile="True"/>
         <column name="ruleMinValue" dataType="Double" displayName="Minimum Value"/>
@@ -139,7 +139,6 @@
     <!--Transformer 1: training classifier-->
     <transformer name="TrainClassifier" displayName="1-Train Classifier" programName="Rscript" programArguments="1-train-classifier.R" condaEnv="ecoClassify-conda.yml" condaEnvVersion="1.3">
         <dataSheet name="InputTrainingRasters" type="Input"/>
-        <dataSheet name="InputPredictingRasters" type="Input"/>
         <dataSheet name="InputTrainingCovariates" type="Input"/>
         <dataSheet name="ClassifierOptions" type="Input"/>
         <dataSheet name="AdvancedClassifierOptions" type="Input"/>


### PR DESCRIPTION
- Move filtering step into a post-processing transformer
- Add a rule-based restriction to the post-processing transformer
- Change display name of "Ground Truth Raster" to "User Classified Raster"
- Update run log with progress
- Move "optional" inputs into Advanced datasheet
- Add default records for "required" inputs
- Remove `InputPredictingRasters` from transformer 1
- Standardize cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated post-processing workflow enabling filtering and rule-based reclassification of raster outputs.
  * Added new options for advanced classifier settings and post-processing filters and rules.
  * New outputs for restricted (filtered and reclassified) predicted and classified rasters are now available.

* **Improvements**
  * Enhanced progress messaging and user feedback during workflow execution.
  * Reorganized classifier options into basic and advanced categories for improved usability.
  * Improved readability and clarity of user-facing options and terminology.
  * Streamlined prediction and training workflows by disabling filtering-related parameters and outputs.

* **Bug Fixes**
  * Disabled previously unused or redundant filtering options to streamline workflows.

* **Documentation**
  * Updated display names and scenario/map/export layouts for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->