### PR TITLE
Af-skip-broken-timesteps

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,9 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = false
+exclude = []
+default-exclude = true
+skip = []

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,8 @@
+linters: linters_with_defaults(
+  object_name_linter("camelCase"),
+  return_linter(
+  return_style = c("explicit")
+  ),
+  line_length_linter = NULL
+  )
+encoding: "UTF-8"

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -133,12 +133,17 @@ groundTruthRasterList <- flt$groundTruthRasterList
 if (!is.null(flt$kept_timesteps)) {
   timestepList <- flt$kept_timesteps
 }
+## guard: if all timesteps were dropped, abort early with a clear message
+if (length(trainingRasterList) == 0) {
+  warning(
+    "All timesteps were dropped because of missing data or projection issues; no data available for training."
+  )
+  stop("Aborting: no valid timesteps remain after filtering.")
+}
+
 
 # Add covariate data to training rasters
-trainingRasterList <- addCovariates(
-  trainingRasterList,
-  trainingCovariateRaster
-)
+trainingRasterList <- addCovariates(trainingRasterList, trainingCovariateRaster)
 
 # Check for NA values in training rasters
 # NOTE: Masking is not applied, but a message is returned if there are an uneven
@@ -146,11 +151,7 @@ trainingRasterList <- addCovariates(
 checkNA(trainingRasterList)
 
 # Separate training and testing data
-splitData <- splitTrainTest(
-  trainingRasterList,
-  groundTruthRasterList,
-  nObs
-)
+splitData <- splitTrainTest(trainingRasterList, groundTruthRasterList, nObs)
 allTrainData <- splitData[[1]]
 allTestData <- splitData[[2]]
 

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -124,8 +124,15 @@ trainingCovariateRaster <- processCovariates(
 ## filtered out timesteps with issues
 flt <- skipBadTimesteps(
   trainingRasterList,
-  groundTruthRasterList
+  groundTruthRasterList,
+  timesteps = timestepList
 )
+## using filtered datasets going forward
+trainingRasterList <- flt$trainingRasterList
+groundTruthRasterList <- flt$groundTruthRasterList
+if (!is.null(flt$kept_timesteps)) {
+  timestepList <- flt$kept_timesteps
+}
 
 # Add covariate data to training rasters
 trainingRasterList <- addCovariates(
@@ -140,8 +147,8 @@ checkNA(trainingRasterList)
 
 # Separate training and testing data
 splitData <- splitTrainTest(
-  flt$trainingRasterList,
-  flt$groundTruthRasterList,
+  trainingRasterList,
+  groundTruthRasterList,
   nObs
 )
 allTrainData <- splitData[[1]]

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -339,7 +339,7 @@ for (t in seq_along(trainingRasterList)) {
     predictedPresence,
     groundTruth,
     probabilityRaster,
-    trainingRasterList,
+    trainingRasterList[[timestep]],
     category = "training",
     timestep,
     transferDir

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -339,7 +339,7 @@ for (t in seq_along(trainingRasterList)) {
     predictedPresence,
     groundTruth,
     probabilityRaster,
-    trainingRasterList[[timestep]],
+    trainingRasterList[[t]],
     category = "training",
     timestep,
     transferDir

--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -124,8 +124,7 @@ trainingCovariateRaster <- processCovariates(
 ## filtered out timesteps with issues
 flt <- skipBadTimesteps(
   trainingRasterList,
-  groundTruthRasterList,
-  timesteps = Timesteps # if you have a vector of timestep labels; otherwise omit
+  groundTruthRasterList
 )
 
 # Add covariate data to training rasters

--- a/src/2-predict.r
+++ b/src/2-predict.r
@@ -177,7 +177,7 @@ for (t in seq_along(predictRasterList)) {
     classifiedPresence,
     groundTruth = NULL,
     classifiedProbability,
-    predictRasterList,
+    predictRasterList[[timestep]],
     category = "predicting",
     timestep,
     transferDir

--- a/src/2-predict.r
+++ b/src/2-predict.r
@@ -177,7 +177,7 @@ for (t in seq_along(predictRasterList)) {
     classifiedPresence,
     groundTruth = NULL,
     classifiedProbability,
-    predictRasterList[[timestep]],
+    predictRasterList[[t]],
     category = "predicting",
     timestep,
     transferDir

--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -84,6 +84,7 @@ skipBadTimesteps <- function(
   # Assemble outputs
   keptTraining <- trainingRasterList[keptIdx]
   keptGroundTruth <- groundTruthRasterList[keptIdx]
+  keptTimesteps <- if (!is.null(timesteps)) timesteps[keptIdx] else NULL
 
   droppedIdx <- which(!keptIdx)
   dropped <- if (length(droppedIdx)) {
@@ -131,7 +132,8 @@ skipBadTimesteps <- function(
   list(
     trainingRasterList = keptTraining,
     groundTruthRasterList = keptGroundTruth,
-    dropped = dropped
+    dropped = dropped,
+    keptTimesteps = keptTimesteps
   )
 }
 
@@ -611,11 +613,7 @@ splitTrainTest <- function(
     stop("Training data must include both classes overall.")
   }
 
-  list(
-    train = trainDf,
-    test = testDf,
-    samplingInfo = samplingInfo
-  )
+  list(train = trainDf, test = testDf, samplingInfo = samplingInfo)
 }
 
 #' Compute metrics at a threshold

--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -1029,7 +1029,7 @@ saveFiles <- function(
   predictedPresence,
   groundTruth = NULL,
   probabilityRaster,
-  trainingRasterList,
+  trainingRaster,
   category,
   timestep,
   transferDir
@@ -1084,6 +1084,6 @@ saveFiles <- function(
       ".png"
     ))
   )
-  plotRGB(trainingRasterList[[t]], r = 3, g = 2, b = 1, stretch = "lin")
+  plotRGB(trainingRaster, r = 3, g = 2, b = 1, stretch = "lin")
   dev.off()
 }

--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -653,14 +653,14 @@ getSensSpec <- function(probs, actual, threshold) {
 #'
 #' @description
 #' Selects a threshold over \code{0.01..0.99} maximizing an objective
-#' (\code{"youden"}, \code{"accuracy"}, \code{"specificity"},
-#' \code{"sensitivity"}, \code{"precision"}, \code{"balanced"}),
+#' (\code{"Youden"}, \code{"Accuracy"}, \code{"Specificity"},
+#' \code{"Sensitivity"}, \code{"Precision"}, \code{"Balanced"}),
 #' with optional minimum metric constraints.
 #'
 #' @param model Trained model object (CNN, RF, or MaxEnt).
 #' @param testingData Data frame with \code{presence} and predictors.
 #' @param modelType One of \code{"Random Forest"}, \code{"MaxEnt"}, \code{"CNN"}.
-#' @param objective Objective to maximize; default \code{"youden"}.
+#' @param objective Objective to maximize; default \code{"Youden"}.
 #' @param min_sensitivity Optional minimum sensitivity in [0, 1].
 #' @param min_specificity Optional minimum specificity in [0, 1].
 #' @param min_precision Optional minimum precision in [0, 1].


### PR DESCRIPTION
Created a function to skip over broken timesteps and throw a warning instead of an error 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Per-timestep filtering that reports kept/dropped timesteps with reasons; optional alignment/resampling checks.

- **Bug Fixes**
  - Abort with clear warning when all timesteps are dropped; clearer warnings when samples are insufficient or single-class.

- **Refactor**
  - Major rewrite of class-balanced, per-timestep train/test sampling and related logging; improved threshold selection and pipeline clarity.

- **Chores**
  - Added formatter and linter configs; per-timestep outputs now save the specific timestep raster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->