### PR TITLE
Ha fix extract rasters

### DIFF
--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -1008,7 +1008,7 @@ getRgbDataframe <- function(
 #' @param groundTruth Optional SpatRaster containing ground truth presence values
 #' (can be NULL if unavailable).
 #' @param probabilityRaster A SpatRaster containing continuous probability predictions.
-#' @param trainingRasterList A list of SpatRaster stacks used to generate the RGB image.
+#' @param trainingRaster A SpatRaster used to generate the RGB image.
 #' @param category A character string used to label file outputs (e.g., "training" or "predicting").
 #' @param timestep Integer indicating the current timestep for file naming.
 #' @param transferDir File path to the directory where outputs will be written.
@@ -1097,10 +1097,10 @@ saveFiles <- function(
 
   # --- plot PNG safely ---
   png_file <- file.path(paste0(transferDir, "/RGBImage-", category, "-t", timestep, ".png"))
-  try({
-    grDevices::png(filename = png_file)
-    # now r=1,g=2,b=3 always exists on this mini-stack
+  grDevices::png(filename = png_file)
+  tryCatch({
     terra::plotRGB(rgb_rast, r = 1, g = 2, b = 3, stretch = "lin")
-    grDevices::dev.off()
-  }, silent = TRUE)
+  }, error = function(e) {
+    updateRunLog(sprintf("t=%s: Failed to write RGB PNG: %s", timestep, conditionMessage(e)), type = "warning")
+  })
 }

--- a/src/functions/0.2-training-and-prediction.r
+++ b/src/functions/0.2-training-and-prediction.r
@@ -209,7 +209,7 @@ splitTrainTest <- function(
 
   # helper: estimate class labels (0/1) and minority from a quick GT sample (no full scan)
   estimate_classes <- function(r_gt, sample_n = quick_prop_sample) {
-    s <- min(sample_n, max(1000L, floor(terra::ncell(r_gt) * 0.001)))
+    s <- min(sample_n, max(5000L, floor(0.01 * terra::ncell(r_gt))))
     gt_samp <- try(
       terra::spatSample(
         r_gt,
@@ -1103,5 +1103,4 @@ saveFiles <- function(
     terra::plotRGB(rgb_rast, r = 1, g = 2, b = 3, stretch = "lin")
     grDevices::dev.off()
   }, silent = TRUE)
-
 }

--- a/src/functions/0.4-CNN.r
+++ b/src/functions/0.4-CNN.r
@@ -149,8 +149,9 @@ getCNNModel <- function(allTrainData, nCores, isTuningOn) {
         # store each categorical column as a 1-D [n] long tensor
         self$X_cat <- lapply(seq_along(X_cat), function(i) {
           v <- as.integer(X_cat[[i]])
-          # map NA to "unknown" bucket at end
-          nlev <- max(v, na.rm = TRUE)
+          # map NA to "unknown" bucket at end; tolerate all-NA by treating base levels as 0
+          nlev <- suppressWarnings(max(v, na.rm = TRUE))
+          if (!is.finite(nlev)) nlev <- 0L
           v[is.na(v)] <- nlev + 1L
           torch_tensor(unname(v), dtype = torch_long())$view(c(self$n))
         })

--- a/src/functions/0.4-CNN.r
+++ b/src/functions/0.4-CNN.r
@@ -201,7 +201,7 @@ getCNNModel <- function(allTrainData, nCores, isTuningOn) {
 
     list(x_num = x_num, x_cat = x_cat, y = y)
   }
-  
+
   dl <- torch::dataloader(
     ds,
     batch_size = if (isTuningOn) 64L else 32L,

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <package 
-    name="ecoClassify" displayName="ecoClassify" version="2.2.0"
+    name="ecoClassify" displayName="ecoClassify" version="2.2.1"
     description="Image classifier using semantic image segmentation" 
     url="https://apexrms.github.io/ecoClassify/" 
     minSyncroSimVersion="3.1.0">


### PR DESCRIPTION
Bug fixes
* extractRaster function can now handle multiple training raster inputs
* corrected dimensions for CNN model when trained on multiple training rasters with the contextualization feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added CNN prediction helper for tabular data with unseen categorical-level handling and class/probability outputs.
* Bug Fixes
  * Safer, more robust RGB image export covering 0–3+ band cases and plotting errors.
  * Improved preprocessing of timesteps and missing values producing a named list of rasters and consistent ground-truth handling.
  * More reliable CNN training/prediction with updated batching and metadata-driven model loading.
* Chores
  * Bumped package version to 2.2.1; public API parameter for saveFiles updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->