### PR TITLE
Switch post-processing order

### DIFF
--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -136,7 +136,8 @@ for (t in trainTimestepList) {
       fillValue,
       "training",
       t,
-      transferDir
+      transferDir,
+      fileName = "filteredPredictedPresence"
     )
 
     # Combine results
@@ -166,7 +167,8 @@ for (t in predTimestepList) {
       fillValue,
       "predicting",
       t,
-      transferDir
+      transferDir,
+      fileName = "filteredPredictedPresence"
     )
 
     # Combine results
@@ -290,7 +292,8 @@ if (nrow(ruleReclassDataframe) != 0) {
           fillValue,
           "training",
           t,
-          restrictedTmpDir
+          restrictedTmpDir,
+          fileName = "PredictedPresenceFilteredRestricted"
         )
 
         reclassedFilteredPathTrain <- file.path(
@@ -415,7 +418,8 @@ if (nrow(ruleReclassDataframe) != 0) {
           fillValue,
           "predicting",
           t,
-          restrictedTmpDir
+          restrictedTmpDir,
+          fileName = "PredictedPresenceFilteredRestricted"
         )
 
         reclassedFilteredPathPred <- file.path(

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -289,11 +289,6 @@ if (nrow(ruleReclassDataframe) != 0) {
           fileName = "PredictedPresenceFilteredRestricted"
         )
 
-        reclassedFilteredPathTrain <- file.path(
-          transferDir,
-          paste0("PredictedPresenceFilteredRestricted-","training","-t",t,".tif")
-        )
-
         writeRaster(
           rast(filteredRestricted$PredictedFiltered),
           filename = reclassedFilteredPathTrain,
@@ -411,11 +406,6 @@ if (nrow(ruleReclassDataframe) != 0) {
           t,
           restrictedTmpDir,
           fileName = "PredictedPresenceFilteredRestricted"
-        )
-
-        reclassedFilteredPathPred <- file.path(
-          transferDir,
-          paste0("PredictedPresenceFilteredRestricted-","predicting","-t",t,".tif")
         )
 
         writeRaster(

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -155,7 +155,7 @@ for (t in predTimestepList) {
     predictingOutputDataframe$Timestep == t
   ]
 
-  if (!is.null(classifiedPresenceFilepath)) {
+  if (!is.na(classifiedPresenceFilepath) && file.exists(classifiedPresenceFilepath)) {
     # Load raster
     predictedPresence <- rast(classifiedPresenceFilepath)
 

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -188,7 +188,7 @@ if (nrow(ruleReclassDataframe) != 0) {
   dir.create(restrictedTmpDir, showWarnings = FALSE, recursive = TRUE)
 
   # ---- Apply Reclassification Rules (training: unfiltered + filtered) ----
-  if (!is_empty(trainTimestepList)) {
+  if (length(trainTimestepList) > 0) {
     for (t in trainTimestepList) {
 
       # Get file paths
@@ -319,7 +319,7 @@ if (nrow(ruleReclassDataframe) != 0) {
   }
 
   # ---- Apply Reclassification Rules (predicting: unfiltered + filtered) ----
-  if (!is_empty(predTimestepList)) {
+  if (length(predTimestepList) > 0) {
     for (t in predTimestepList) {
 
       # Get file paths

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -324,7 +324,7 @@ if (nrow(ruleReclassDataframe) != 0) {
 
         trainingOutputDataframe$PredictedFilteredRestricted[
           trainingOutputDataframe$Timestep == t
-        ] <- filteredRestricted$PredictedFiltered
+        ] <- reclassedFilteredPathTrain
       }
 
       # Cleanup per-timestep
@@ -461,7 +461,7 @@ if (nrow(ruleReclassDataframe) != 0) {
           transferDir,
           paste0("PredictedPresenceFilteredRestricted-","predicting","-t",t,".tif")
         )
-        
+
         writeRaster(
           rast(filteredRestricted$PredictedFiltered),
           filename = reclassedFilteredPathPred,
@@ -470,7 +470,7 @@ if (nrow(ruleReclassDataframe) != 0) {
 
         predictingOutputDataframe$ClassifiedFilteredRestricted[
           predictingOutputDataframe$Timestep == t
-        ] <- filteredRestricted$PredictedFiltered
+        ] <- reclassedFilteredPathPred
       }
 
       # Cleanup per-timestep

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -214,7 +214,15 @@ if (nrow(ruleReclassDataframe) != 0) {
       for (i in seq_len(nrow(ruleReclassDataframe))) {
 
           # Load rule raster
-          ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
+          rulePath <- ruleReclassDataframe$ruleRasterFile[i]
+          if (length(rulePath) == 0 || is.na(rulePath) || !file.exists(rulePath)) {
+            updateRunLog(
+              paste0("Rule raster missing for rule index ", i, "; skipping."),
+              type = "warning"
+            )
+            next
+          }
+          ruleRaster <- rast(rulePath)
 
           # Ensure geometry match; skip (or resample here if desired)
           if (!compareGeom(ruleRaster, reclassedUnf, stopOnError = FALSE)) {
@@ -228,6 +236,21 @@ if (nrow(ruleReclassDataframe) != 0) {
           vmin <- ruleReclassDataframe$ruleMinValue[i]
           vmax <- ruleReclassDataframe$ruleMaxValue[i]
           rval <- as.numeric(ruleReclassDataframe$ruleReclassValue[i]) - 1
+
+          if (any(is.na(c(vmin, vmax, rval)))) {
+            updateRunLog(
+              paste0("Rule values (min/max/reclass) contain NA for rule index ", i, "; skipping."),
+              type = "warning"
+            )
+            next
+          }
+          if (vmin > vmax) {
+            tmp <- vmin; vmin <- vmax; vmax <- tmp
+            updateRunLog(
+              paste0("Swapped vmin/vmax for rule index ", i, " to maintain [min,max]."),
+              type = "info"
+            )
+          }
 
           if (isTRUE(vmin == vmax)) {
             # ---------- CATEGORICAL: apply where ruleRaster == vmin ----------
@@ -332,7 +355,15 @@ if (nrow(ruleReclassDataframe) != 0) {
       for (i in seq_len(nrow(ruleReclassDataframe))) {
 
           # Load rule raster
-          ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
+          rulePath <- ruleReclassDataframe$ruleRasterFile[i]
+          if (length(rulePath) == 0 || is.na(rulePath) || !file.exists(rulePath)) {
+            updateRunLog(
+              paste0("Rule raster missing for rule index ", i, "; skipping."),
+              type = "warning"
+            )
+            next
+          }
+          ruleRaster <- rast(rulePath)
 
           # Ensure same geometry; otherwise skip (or resample if you prefer)
           if (!compareGeom(ruleRaster, reclassedUnf, stopOnError = FALSE)) {
@@ -346,6 +377,21 @@ if (nrow(ruleReclassDataframe) != 0) {
           vmin <- ruleReclassDataframe$ruleMinValue[i]
           vmax <- ruleReclassDataframe$ruleMaxValue[i]
           rval <- as.numeric(ruleReclassDataframe$ruleReclassValue[i]) - 1
+
+          if (any(is.na(c(vmin, vmax, rval)))) {
+            updateRunLog(
+              paste0("Rule values (min/max/reclass) contain NA for rule index ", i, "; skipping."),
+              type = "warning"
+            )
+            next
+          }
+          if (vmin > vmax) {
+            tmp <- vmin; vmin <- vmax; vmax <- tmp
+            updateRunLog(
+              paste0("Swapped vmin/vmax for rule index ", i, " to maintain [min,max]."),
+              type = "info"
+            )
+          }
 
           if (isTRUE(vmin == vmax)) {
             # ---------- CATEGORICAL: apply where ruleRaster == vmin ----------

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -182,6 +182,9 @@ for (t in predTimestepList) {
 progressBar(type = "message", message = "Reclassifying")
 
 if (nrow(ruleReclassDataframe) != 0) {
+  restrictedTmpDir <- file.path(transferDir, "restrictedTmpDir")
+  dir.create(restrictedTmpDir, showWarnings = FALSE, recursive = TRUE)
+
   # ---- Apply Reclassification Rules (training: unfiltered + filtered) ----
   if (!is_empty(trainTimestepList)) {
     for (t in trainTimestepList) {
@@ -287,12 +290,18 @@ if (nrow(ruleReclassDataframe) != 0) {
           fillValue,
           "training",
           t,
-          transferDir
+          restrictedTmpDir
         )
 
         reclassedFilteredPathTrain <- file.path(
           transferDir,
           paste0("PredictedPresenceFilteredRestricted-","training","-t",t,".tif")
+        )
+
+        writeRaster(
+          rast(filteredRestricted$PredictedFiltered),
+          filename = reclassedFilteredPathTrain,
+          overwrite = TRUE, wopt = wopt_int
         )
 
         trainingOutputDataframe$PredictedFilteredRestricted[
@@ -406,12 +415,18 @@ if (nrow(ruleReclassDataframe) != 0) {
           fillValue,
           "predicting",
           t,
-          transferDir
+          restrictedTmpDir
         )
 
         reclassedFilteredPathPred <- file.path(
           transferDir,
           paste0("PredictedPresenceFilteredRestricted-","predicting","-t",t,".tif")
+        )
+
+        writeRaster(
+          rast(filteredRestricted$PredictedFiltered),
+          filename = reclassedFilteredPathPred,
+          overwrite = TRUE, wopt = wopt_int
         )
 
         predictingOutputDataframe$ClassifiedFilteredRestricted[

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -267,7 +267,8 @@ if (nrow(ruleReclassDataframe) != 0) {
             rtab <- matrix(c(vmin, vmax, rval), ncol = 3, byrow = TRUE)
             classedMask <- classify(
               ruleRaster, rtab, others = NA,
-              filename = tempfile(fileext = ".tif"), overwrite = TRUE
+              filename = tempfile(fileext = ".tif"), overwrite = TRUE,
+              right = FALSE, include.lowest = TRUE
             )
 
             # Update where mask is not NA
@@ -413,7 +414,8 @@ if (nrow(ruleReclassDataframe) != 0) {
             rtab <- matrix(c(vmin, vmax, rval), ncol = 3, byrow = TRUE)
             classedMask <- classify(
               ruleRaster, rtab, others = NA,
-              filename = tempfile(fileext = ".tif"), overwrite = TRUE
+              filename = tempfile(fileext = ".tif"), overwrite = TRUE,
+              right = FALSE, include.lowest = TRUE
             )
 
             # Update where mask is not NA (i.e., cells under the rule)

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -181,292 +181,254 @@ for (t in predTimestepList) {
 
 progressBar(type = "message", message = "Reclassifying")
 
+if (nrow(ruleReclassDataframe) != 0) {
+  # ---- Apply Reclassification Rules (training: unfiltered + filtered) ----
+  if (!is_empty(trainTimestepList)) {
+    for (t in trainTimestepList) {
 
-# ---- Apply Reclassification Rules (training: unfiltered + filtered) ----
-if (!is_empty(trainTimestepList)) {
-  for (t in trainTimestepList) {
-
-    # Get file paths
-    unfilteredTrainFilepath <- trainingOutputDataframe$PredictedUnfiltered[
-      trainingOutputDataframe$Timestep == t
-    ]
-    filteredTrainFilepath <- trainingOutputDataframe$PredictedFiltered[
-      trainingOutputDataframe$Timestep == t
-    ]
-
-    # Skip if no unfiltered path
-    if (is.na(unfilteredTrainFilepath)) next
-
-    # Load base rasters
-    unfiltered <- rast(unfilteredTrainFilepath)
-
-    # Disk-backed working copies
-    reclassedUnf <- writeRaster(
-      unfiltered, filename = tempfile(fileext = ".tif"),
-      overwrite = TRUE, wopt = wopt_int
-    )
-
-    hasFiltered <- !is.na(filteredTrainFilepath)
-    if (hasFiltered) {
-      filtered <- rast(filteredTrainFilepath)
-      reclassedFil <- writeRaster(
-        filtered, filename = tempfile(fileext = ".tif"),
-        overwrite = TRUE, wopt = wopt_int
-      )
-    } else {
-      filtered <- reclassedFil <- NULL
-    }
-
-    # Rules
-    if (nrow(ruleReclassDataframe) == 0) {
-      updateRunLog(
-        "No rule-based reclassification rules found. Skipping reclassification.",
-        type = "warning"
-      )
-    } else {
-      for (i in seq_len(nrow(ruleReclassDataframe))) {
-
-        # Load rule raster
-        ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
-
-        # Ensure geometry match; skip (or resample here if desired)
-        if (!compareGeom(ruleRaster, reclassedUnf, stopOnError = FALSE)) {
-          updateRunLog(
-            "Rule raster extent does not match unfiltered training raster extent. Skipping reclassification.",
-            type = "warning"
-          )
-          next
-        }
-
-        vmin <- ruleReclassDataframe$ruleMinValue[i]
-        vmax <- ruleReclassDataframe$ruleMaxValue[i]
-        rval <- as.numeric(ruleReclassDataframe$ruleReclassValue[i]) - 1
-
-        if (isTRUE(vmin == vmax)) {
-          # ---------- CATEGORICAL: apply where ruleRaster == vmin ----------
-          tmpUnf <- tempfile(fileext = ".tif")
-          reclassedUnf <- ifel(
-            ruleRaster == vmin,
-            rval,
-            reclassedUnf,
-            filename = tmpUnf, overwrite = TRUE
-          )
-
-          if (hasFiltered) {
-            tmpFil <- tempfile(fileext = ".tif")
-            reclassedFil <- ifel(
-              ruleRaster == vmin,
-              rval,
-              reclassedFil,
-              filename = tmpFil, overwrite = TRUE
-            )
-          }
-
-        } else {
-          # ---------- CONTINUOUS: classify range [vmin, vmax] ----------
-          rtab <- matrix(c(vmin, vmax, rval), ncol = 3, byrow = TRUE)
-          classedMask <- classify(
-            ruleRaster, rtab, others = NA,
-            filename = tempfile(fileext = ".tif"), overwrite = TRUE
-          )
-
-          # Update where mask is not NA
-          tmpUnf <- tempfile(fileext = ".tif")
-          reclassedUnf <- ifel(
-            !is.na(classedMask),
-            rval,
-            reclassedUnf,
-            filename = tmpUnf, overwrite = TRUE
-          )
-
-          if (hasFiltered) {
-            tmpFil <- tempfile(fileext = ".tif")
-            reclassedFil <- ifel(
-              !is.na(classedMask),
-              rval,
-              reclassedFil,
-              filename = tmpFil, overwrite = TRUE
-            )
-          }
-
-          rm(classedMask); gc()
-        }
-
-        gc()
-      }
-    }
-
-    # ---- Final writes for timestep t ----
-    reclassedPathTrain <- file.path(
-      transferDir,
-      paste0("PredictedPresenceRestricted-","training","-t",t,".tif")
-    )
-    reclassedUnf <- writeRaster(
-      reclassedUnf, filename = reclassedPathTrain,
-      overwrite = TRUE, wopt = wopt_int
-    )
-    trainingOutputDataframe$PredictedUnfilteredRestricted[
-      trainingOutputDataframe$Timestep == t
-    ] <- reclassedPathTrain
-
-    if (!is.null(reclassedFil)) {
-      reclassedFilteredPathTrain <- file.path(
-        transferDir,
-        paste0("PredictedPresenceFilteredRestricted-","training","-t",t,".tif")
-      )
-      reclassedFil <- writeRaster(
-        reclassedFil, filename = reclassedFilteredPathTrain,
-        overwrite = TRUE, wopt = wopt_int
-      )
-      trainingOutputDataframe$PredictedFilteredRestricted[
+      # Get file paths
+      unfilteredTrainFilepath <- trainingOutputDataframe$PredictedUnfiltered[
         trainingOutputDataframe$Timestep == t
-      ] <- reclassedFilteredPathTrain
-    }
+      ]
+      filteredTrainFilepath <- trainingOutputDataframe$PredictedFiltered[
+        trainingOutputDataframe$Timestep == t
+      ]
 
-    # Cleanup per-timestep
-    rm(unfiltered, filtered, reclassedUnf, reclassedFil); gc()
-  }
-}
+      # Skip if no unfiltered path
+      if (is.na(unfilteredTrainFilepath)) next
 
-# ---- Apply Reclassification Rules (predicting: unfiltered + filtered) ----
-if (!is_empty(predTimestepList)) {
-  for (t in predTimestepList) {
+      # Load base rasters
+      unfiltered <- rast(unfilteredTrainFilepath)
 
-    # Get file paths
-    unfilteredPredFilepath <- predictingOutputDataframe$ClassifiedUnfiltered[
-      predictingOutputDataframe$Timestep == t
-    ]
-    filteredPredFilepath <- predictingOutputDataframe$ClassifiedFiltered[
-      predictingOutputDataframe$Timestep == t
-    ]
-
-    # Skip if no unfiltered path
-    if (is.na(unfilteredPredFilepath)) next
-
-    # Load rasters
-    unfiltered <- rast(unfilteredPredFilepath)
-
-    # Start disk-backed working copies
-    reclassedUnf <- writeRaster(
-      unfiltered, filename = tempfile(fileext = ".tif"),
-      overwrite = TRUE, wopt = wopt_int
-    )
-
-    hasFiltered <- !is.na(filteredPredFilepath)
-    if (hasFiltered) {
-      filtered <- rast(filteredPredFilepath)
-      reclassedFil <- writeRaster(
-        filtered, filename = tempfile(fileext = ".tif"),
+      # Disk-backed working copies
+      reclassedUnf <- writeRaster(
+        unfiltered, filename = tempfile(fileext = ".tif"),
         overwrite = TRUE, wopt = wopt_int
       )
-    } else {
-      filtered <- reclassedFil <- NULL
-    }
 
-    # Apply rules (if any)
-    if (nrow(ruleReclassDataframe) != 0) {
-      for (i in seq_len(nrow(ruleReclassDataframe))) {
+      # Rules
+      if (nrow(ruleReclassDataframe) == 0) {
+        updateRunLog(
+          "No rule-based reclassification rules found. Skipping reclassification.",
+          type = "warning"
+        )
+      } else {
+        for (i in seq_len(nrow(ruleReclassDataframe))) {
 
-        # Load rule raster
-        ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
+          # Load rule raster
+          ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
 
-        # Ensure same geometry; otherwise skip (or resample if you prefer)
-        if (!compareGeom(ruleRaster, reclassedUnf, stopOnError = FALSE)) {
-          updateRunLog(
-            "Rule raster extent does not match predicting raster extent. Skipping reclassification.",
-            type = "warning"
-          )
-          next
-        }
+          # Ensure geometry match; skip (or resample here if desired)
+          if (!compareGeom(ruleRaster, reclassedUnf, stopOnError = FALSE)) {
+            updateRunLog(
+              "Rule raster extent does not match unfiltered training raster extent. Skipping reclassification.",
+              type = "warning"
+            )
+            next
+          }
 
-        vmin <- ruleReclassDataframe$ruleMinValue[i]
-        vmax <- ruleReclassDataframe$ruleMaxValue[i]
-        rval <- as.numeric(ruleReclassDataframe$ruleReclassValue[i]) - 1
+          vmin <- ruleReclassDataframe$ruleMinValue[i]
+          vmax <- ruleReclassDataframe$ruleMaxValue[i]
+          rval <- as.numeric(ruleReclassDataframe$ruleReclassValue[i]) - 1
 
-        if (isTRUE(vmin == vmax)) {
-          # ---------- CATEGORICAL: apply where ruleRaster == vmin ----------
-          tmpUnf <- tempfile(fileext = ".tif")
-          reclassedUnf <- ifel(
-            ruleRaster == vmin,
-            rval,                 # set to rval where condition true
-            reclassedUnf,         # otherwise keep
-            filename = tmpUnf, overwrite = TRUE
-          )
-
-          if (hasFiltered) {
-            tmpFil <- tempfile(fileext = ".tif")
-            reclassedFil <- ifel(
+          if (isTRUE(vmin == vmax)) {
+            # ---------- CATEGORICAL: apply where ruleRaster == vmin ----------
+            tmpUnf <- tempfile(fileext = ".tif")
+            reclassedUnf <- ifel(
               ruleRaster == vmin,
               rval,
-              reclassedFil,
-              filename = tmpFil, overwrite = TRUE
+              reclassedUnf,
+              filename = tmpUnf, overwrite = TRUE
             )
-          }
 
-        } else {
-          # ---------- CONTINUOUS: classify range [vmin, vmax] ----------
-          rtab <- matrix(c(vmin, vmax, rval), ncol = 3, byrow = TRUE)
-          classedMask <- classify(
-            ruleRaster, rtab, others = NA,
-            filename = tempfile(fileext = ".tif"), overwrite = TRUE
-          )
+          } else {
+            # ---------- CONTINUOUS: classify range [vmin, vmax] ----------
+            rtab <- matrix(c(vmin, vmax, rval), ncol = 3, byrow = TRUE)
+            classedMask <- classify(
+              ruleRaster, rtab, others = NA,
+              filename = tempfile(fileext = ".tif"), overwrite = TRUE
+            )
 
-          # Update where mask is not NA (i.e., cells under the rule)
-          tmpUnf <- tempfile(fileext = ".tif")
-          reclassedUnf <- ifel(
-            !is.na(classedMask),
-            rval,
-            reclassedUnf,
-            filename = tmpUnf, overwrite = TRUE
-          )
-
-          if (hasFiltered) {
-            tmpFil <- tempfile(fileext = ".tif")
-            reclassedFil <- ifel(
+            # Update where mask is not NA
+            tmpUnf <- tempfile(fileext = ".tif")
+            reclassedUnf <- ifel(
               !is.na(classedMask),
               rval,
-              reclassedFil,
-              filename = tmpFil, overwrite = TRUE
+              reclassedUnf,
+              filename = tmpUnf, overwrite = TRUE
             )
+
+            rm(classedMask); gc()
           }
 
-          rm(classedMask); gc()
+          gc()
         }
-
-        gc()
       }
-    }
 
-    # ---- Final writes for timestep t ----
-    reclassedPathPred <- file.path(
-      transferDir,
-      paste0("PredictedPresenceRestricted-","predicting","-t",t,".tif")
-    )
-    reclassedUnf <- writeRaster(
-      reclassedUnf, filename = reclassedPathPred,
-      overwrite = TRUE, wopt = wopt_int
-    )
-    predictingOutputDataframe$ClassifiedUnfilteredRestricted[
-      predictingOutputDataframe$Timestep == t
-    ] <- reclassedPathPred
-
-    if (!is.null(reclassedFil)) {
-      reclassedFilteredPathPred <- file.path(
+      # ---- Final writes for timestep t (restricted) ----
+      reclassedPathTrain <- file.path(
         transferDir,
-        paste0("PredictedPresenceFilteredRestricted-","predicting","-t",t,".tif")
+        paste0("PredictedPresenceRestricted-","training","-t",t,".tif")
       )
-      reclassedFil <- writeRaster(
-        reclassedFil, filename = reclassedFilteredPathPred,
+      reclassedUnf <- writeRaster(
+        reclassedUnf, filename = reclassedPathTrain,
         overwrite = TRUE, wopt = wopt_int
       )
-      predictingOutputDataframe$ClassifiedFilteredRestricted[
-        predictingOutputDataframe$Timestep == t
-      ] <- reclassedFilteredPathPred
-    }
+      trainingOutputDataframe$PredictedUnfilteredRestricted[
+        trainingOutputDataframe$Timestep == t
+      ] <- reclassedPathTrain
 
-    # Cleanup per-timestep
-    rm(unfiltered, filtered, reclassedUnf, reclassedFil); gc()
+      # ---- filter after reclassification to create FilteredRestricted ----
+      if (isTRUE(applyFiltering)) {
+        filteredRestricted <- filterRasterDataframe(
+          applyFiltering,
+          rast(reclassedPathTrain),
+          filterValue,
+          fillValue,
+          "training",
+          t,
+          transferDir
+        )
+
+        reclassedFilteredPathTrain <- file.path(
+          transferDir,
+          paste0("PredictedPresenceFilteredRestricted-","training","-t",t,".tif")
+        )
+
+        trainingOutputDataframe$PredictedFilteredRestricted[
+          trainingOutputDataframe$Timestep == t
+        ] <- filteredRestricted$PredictedFiltered
+      }
+
+      # Cleanup per-timestep
+      rm(unfiltered, reclassedUnf); gc()
+
+    }
   }
+
+  # ---- Apply Reclassification Rules (predicting: unfiltered + filtered) ----
+  if (!is_empty(predTimestepList)) {
+    for (t in predTimestepList) {
+
+      # Get file paths
+      unfilteredPredFilepath <- predictingOutputDataframe$ClassifiedUnfiltered[
+        predictingOutputDataframe$Timestep == t
+      ]
+      filteredPredFilepath <- predictingOutputDataframe$ClassifiedFiltered[
+        predictingOutputDataframe$Timestep == t
+      ]
+
+      # Skip if no unfiltered path
+      if (is.na(unfilteredPredFilepath)) next
+
+      # Load rasters
+      unfiltered <- rast(unfilteredPredFilepath)
+
+      # Start disk-backed working copies
+      reclassedUnf <- writeRaster(
+        unfiltered, filename = tempfile(fileext = ".tif"),
+        overwrite = TRUE, wopt = wopt_int
+      )
+
+      # Apply rules (if any)
+      if (nrow(ruleReclassDataframe) != 0) {
+        for (i in seq_len(nrow(ruleReclassDataframe))) {
+
+          # Load rule raster
+          ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
+
+          # Ensure same geometry; otherwise skip (or resample if you prefer)
+          if (!compareGeom(ruleRaster, reclassedUnf, stopOnError = FALSE)) {
+            updateRunLog(
+              "Rule raster extent does not match predicting raster extent. Skipping reclassification.",
+              type = "warning"
+            )
+            next
+          }
+
+          vmin <- ruleReclassDataframe$ruleMinValue[i]
+          vmax <- ruleReclassDataframe$ruleMaxValue[i]
+          rval <- as.numeric(ruleReclassDataframe$ruleReclassValue[i]) - 1
+
+          if (isTRUE(vmin == vmax)) {
+            # ---------- CATEGORICAL: apply where ruleRaster == vmin ----------
+            tmpUnf <- tempfile(fileext = ".tif")
+            reclassedUnf <- ifel(
+              ruleRaster == vmin,
+              rval,                 # set to rval where condition true
+              reclassedUnf,         # otherwise keep
+              filename = tmpUnf, overwrite = TRUE
+            )
+
+          } else {
+            # ---------- CONTINUOUS: classify range [vmin, vmax] ----------
+            rtab <- matrix(c(vmin, vmax, rval), ncol = 3, byrow = TRUE)
+            classedMask <- classify(
+              ruleRaster, rtab, others = NA,
+              filename = tempfile(fileext = ".tif"), overwrite = TRUE
+            )
+
+            # Update where mask is not NA (i.e., cells under the rule)
+            tmpUnf <- tempfile(fileext = ".tif")
+            reclassedUnf <- ifel(
+              !is.na(classedMask),
+              rval,
+              reclassedUnf,
+              filename = tmpUnf, overwrite = TRUE
+            )
+
+            rm(classedMask); gc()
+          }
+
+          gc()
+        }
+      }
+
+      # ---- Final writes for timestep t ----
+      reclassedPathPred <- file.path(
+        transferDir,
+        paste0("PredictedPresenceRestricted-","predicting","-t",t,".tif")
+      )
+      reclassedUnf <- writeRaster(
+        reclassedUnf, filename = reclassedPathPred,
+        overwrite = TRUE, wopt = wopt_int
+      )
+      predictingOutputDataframe$ClassifiedUnfilteredRestricted[
+        predictingOutputDataframe$Timestep == t
+      ] <- reclassedPathPred
+
+      # ---- filter after reclassification to create FilteredRestricted ----
+      if (isTRUE(applyFiltering)) {
+        filteredRestricted <- filterRasterDataframe(
+          applyFiltering,
+          rast(reclassedPathPred),
+          filterValue,
+          fillValue,
+          "predicting",
+          t,
+          transferDir
+        )
+
+        reclassedFilteredPathPred <- file.path(
+          transferDir,
+          paste0("PredictedPresenceFilteredRestricted-","predicting","-t",t,".tif")
+        )
+
+        predictingOutputDataframe$ClassifiedFilteredRestricted[
+          predictingOutputDataframe$Timestep == t
+        ] <- filteredRestricted$PredictedFiltered
+      }
+
+      # Cleanup per-timestep
+      rm(unfiltered, reclassedUnf); gc()
+
+    }
+  }
+} else {
+  updateRunLog(
+    "No rule-based reclassification rules found. Skipping reclassification.",
+    type = "warning"
+  )
 }
 
 # Save datasheets --------------------------------------------------------------

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -212,13 +212,7 @@ if (nrow(ruleReclassDataframe) != 0) {
       )
 
       # Rules
-      if (nrow(ruleReclassDataframe) == 0) {
-        updateRunLog(
-          "No rule-based reclassification rules found. Skipping reclassification.",
-          type = "warning"
-        )
-      } else {
-        for (i in seq_len(nrow(ruleReclassDataframe))) {
+      for (i in seq_len(nrow(ruleReclassDataframe))) {
 
           # Load rule raster
           ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
@@ -268,7 +262,6 @@ if (nrow(ruleReclassDataframe) != 0) {
 
           gc()
         }
-      }
 
       # ---- Final writes for timestep t (restricted) ----
       reclassedPathTrain <- file.path(
@@ -343,8 +336,7 @@ if (nrow(ruleReclassDataframe) != 0) {
       )
 
       # Apply rules (if any)
-      if (nrow(ruleReclassDataframe) != 0) {
-        for (i in seq_len(nrow(ruleReclassDataframe))) {
+      for (i in seq_len(nrow(ruleReclassDataframe))) {
 
           # Load rule raster
           ruleRaster <- rast(ruleReclassDataframe$ruleRasterFile[i])
@@ -394,7 +386,6 @@ if (nrow(ruleReclassDataframe) != 0) {
 
           gc()
         }
-      }
 
       # ---- Final writes for timestep t ----
       reclassedPathPred <- file.path(

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -195,12 +195,11 @@ if (nrow(ruleReclassDataframe) != 0) {
       unfilteredTrainFilepath <- trainingOutputDataframe$PredictedUnfiltered[
         trainingOutputDataframe$Timestep == t
       ]
-      filteredTrainFilepath <- trainingOutputDataframe$PredictedFiltered[
-        trainingOutputDataframe$Timestep == t
-      ]
 
       # Skip if no unfiltered path
-      if (is.na(unfilteredTrainFilepath)) next
+      if (length(unfilteredTrainFilepath) == 0 ||
+            is.na(unfilteredTrainFilepath) ||
+            !file.exists(unfilteredTrainFilepath)) next
 
       # Load base rasters
       unfiltered <- rast(unfilteredTrainFilepath)
@@ -314,12 +313,11 @@ if (nrow(ruleReclassDataframe) != 0) {
       unfilteredPredFilepath <- predictingOutputDataframe$ClassifiedUnfiltered[
         predictingOutputDataframe$Timestep == t
       ]
-      filteredPredFilepath <- predictingOutputDataframe$ClassifiedFiltered[
-        predictingOutputDataframe$Timestep == t
-      ]
 
       # Skip if no unfiltered path
-      if (is.na(unfilteredPredFilepath)) next
+      if (length(unfilteredPredFilepath) == 0 ||
+            is.na(unfilteredPredFilepath) ||
+            !file.exists(unfilteredPredFilepath)) next
 
       # Load rasters
       unfiltered <- rast(unfilteredPredFilepath)

--- a/src/3-postprocess.R
+++ b/src/3-postprocess.R
@@ -311,6 +311,11 @@ if (nrow(ruleReclassDataframe) != 0) {
           fileName = "PredictedPresenceFilteredRestricted"
         )
 
+        reclassedFilteredPathTrain <- file.path(
+          transferDir,
+          paste0("PredictedPresenceFilteredRestricted-","training","-t",t,".tif")
+        )
+
         writeRaster(
           rast(filteredRestricted$PredictedFiltered),
           filename = reclassedFilteredPathTrain,
@@ -452,6 +457,11 @@ if (nrow(ruleReclassDataframe) != 0) {
           fileName = "PredictedPresenceFilteredRestricted"
         )
 
+        reclassedFilteredPathPred <- file.path(
+          transferDir,
+          paste0("PredictedPresenceFilteredRestricted-","predicting","-t",t,".tif")
+        )
+        
         writeRaster(
           rast(filteredRestricted$PredictedFiltered),
           filename = reclassedFilteredPathPred,

--- a/src/functions/0.4-random-forest.r
+++ b/src/functions/0.4-random-forest.r
@@ -36,7 +36,7 @@ predictRanger <- function(raster, model) {
   rasterMatrix <- terra::values(raster, mat = TRUE, na.rm = FALSE)
 
   # Find valid cases once
-  valid_idx <- complete.cases(rasterMatrix)
+  valid_idx <- rowSums(!is.na(rasterMatrix)) == ncol(rasterMatrix)
   n_valid <- sum(valid_idx)
 
   if (n_valid == 0) {

--- a/src/functions/0.6-post-processing.r
+++ b/src/functions/0.6-post-processing.r
@@ -298,7 +298,8 @@ filterRasterDataframe <- function(
   fillValue,
   category,
   timestep,
-  transferDir
+  transferDir,
+  fileName
 ) {
   if (!applyFiltering) {
     return(data.frame(
@@ -317,7 +318,9 @@ filterRasterDataframe <- function(
   # File path
   filteredPath <- file.path(paste0(
     transferDir,
-    "/filteredPredictedPresence-",
+    "/",
+    fileName,
+    "-",
     category,
     "-t",
     timestep,

--- a/src/updates/update-2.1.xml
+++ b/src/updates/update-2.1.xml
@@ -13,5 +13,40 @@
     <item>ALTER TABLE ecoClassify_PostProcessingFilter ADD COLUMN fillValue INTEGER</item>
   </action>
 
+  <!-- Modify ClassifierOptions datasheet -->
+  <action code="Exec" condition="TableExists" criteria="ecoClassify_ClassifierOptions">
+    <!-- Remove old columns -->
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN normalizeRasters</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN rasterDecimalPlaces</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN modelTuning</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN setManualThreshold</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN manualThreshold</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN applyContextualization</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN contextualizationWindowSize</item>
+    <item>ALTER TABLE ecoClassify_ClassifierOptions DROP COLUMN setSeed</item>
+  </action>
+
+  <!-- Create new datasheet for advanced classifier options -->
+  <action code="Exec" condition="TableNotExists" criteria="ecoClassify_AdvancedClassifierOptions">
+    <item>CREATE TABLE ecoClassify_AdvancedClassifierOptions(AdvancedClassifierOptionsId INTEGER PRIMARY KEY, normalizeRasters BOOLEAN, rasterDecimalPlaces INTEGER, modelTuning BOOLEAN, setManualThreshold BOOLEAN, manualThreshold DOUBLE, applyContextualization BOOLEAN, contextualizationWindowSize INTEGER, setSeed INTEGER)</item>
+    <item>UPDATE ecoClassify_AdvancedClassifierOptions
+            SET normalizeRasters=0,
+                modelTuning=0,
+                setManualThreshold=0,
+                applyContextualization=0
+            WHERE AdvancedClassifierOptionsId=1</item>
+  </action>
+
+  <!-- Create new datasheet for post processing rule options -->
+  <action code="Exec" condition="TableNotExists" criteria="ecoClassify_PostProcessingRule">
+    <item>CREATE TABLE ecoClassify_PostProcessingRule(PostProcessingRuleId INTEGER PRIMARY KEY, ruleClass INTEGER, ruleRasterFile TEXT, ruleMinValue DOUBLE, ruleMaxValue DOUBLE, ruleReclassValue INTEGER)</item>
+  </action>
+
+  <!-- Modify ClassifiedRasterOutput datasheet -->
+  <action code="Exec" condition="TableExists" criteria="ecoClassify_ClassifiedRasterOutput">
+    <!-- Add new column -->
+    <item>ALTER TABLE ecoClassify_PostProcessingFilter ADD COLUMN ClassifiedUnfilteredRestricted TEXT</item>
+  </action>
+
 </update>
 

--- a/src/updates/update-2.2.xml
+++ b/src/updates/update-2.2.xml
@@ -6,4 +6,14 @@
     <item>ALTER TABLE ecoClassify_AdvancedClassifierOptions ADD COLUMN tuningObjective INTEGER</item>
   </action>
 
+  <action code="Exec" condition="TableExists" criteria="ecoClassify_AdvancedClassifierOptions">
+    <item>UPDATE ecoClassify_AdvancedClassifierOptions
+           SET normalizeRasters=0,
+               modelTuning=0,
+               tuningObjective=5,
+               setManualThreshold=0,
+               applyContextualization=0
+           WHERE AdvancedClassifierOptionsId=1</item>
+  </action>
+
 </update>

--- a/src/updates/update-2.3.xml
+++ b/src/updates/update-2.3.xml
@@ -16,4 +16,19 @@
     <item>ALTER TABLE ecoClassify_RasterOutput ADD COLUMN PredictedFilteredRestricted TEXT</item>
   </action>
 
+  <action code="Exec" condition="TableExists" criteria="ecoClassify_AdvancedClassifierOptions">
+    <item>UPDATE ecoClassify_AdvancedClassifierOptions
+           SET overrideBandnames=0,
+               normalizeRasters=0,
+               rasterDecimalPlaces=2,
+               modelTuning=0,
+               tuningObjective=5,
+               setManualThreshold=0,
+               manualThreshold=0.5,
+               applyContextualization=0,
+               contextualizationWindowSize=3,
+               setSeed=0
+           WHERE AdvancedClassifierOptionsId=1</item>
+  </action>
+
 </update>

--- a/src/updates/update-2.3.xml
+++ b/src/updates/update-2.3.xml
@@ -5,7 +5,7 @@
   <action code="Exec" condition="TableExists" criteria="ecoClassify_AdvancedClassifierOptions">
     <item>ALTER TABLE ecoClassify_AdvancedClassifierOptions ADD COLUMN overrideBandnames BOOLEAN</item>
     <item>UPDATE ecoClassify_AdvancedClassifierOptions
-           SET overrideBandnames=True,
+           SET overrideBandnames=0,
                normalizeRasters=0,
                rasterDecimalPlaces=2,
                modelTuning=0,

--- a/src/updates/update-2.3.xml
+++ b/src/updates/update-2.3.xml
@@ -4,21 +4,8 @@
   <!-- Add new column AdvancedClassifierOptions to AdvancedClassifierOptions -->
   <action code="Exec" condition="TableExists" criteria="ecoClassify_AdvancedClassifierOptions">
     <item>ALTER TABLE ecoClassify_AdvancedClassifierOptions ADD COLUMN overrideBandnames BOOLEAN</item>
-  </action>
-
-  <!-- Add new column ClassifiedFilteredRestricted to ClassifiedRasterOutput -->
-  <action code="Exec" condition="TableExists" criteria="ecoClassify_ClassifiedRasterOutput">
-    <item>ALTER TABLE ecoClassify_ClassifiedRasterOutput ADD COLUMN ClassifiedFilteredRestricted TEXT</item>
-  </action>
-
-  <!-- Add new column PredictedFilteredRestricted to RasterOutput -->
-  <action code="Exec" condition="TableExists" criteria="ecoClassify_RasterOutput">
-    <item>ALTER TABLE ecoClassify_RasterOutput ADD COLUMN PredictedFilteredRestricted TEXT</item>
-  </action>
-
-  <action code="Exec" condition="TableExists" criteria="ecoClassify_AdvancedClassifierOptions">
     <item>UPDATE ecoClassify_AdvancedClassifierOptions
-           SET overrideBandnames=0,
+           SET overrideBandnames=True,
                normalizeRasters=0,
                rasterDecimalPlaces=2,
                modelTuning=0,
@@ -29,6 +16,16 @@
                contextualizationWindowSize=3,
                setSeed=0
            WHERE AdvancedClassifierOptionsId=1</item>
+  </action>
+
+  <!-- Add new column ClassifiedFilteredRestricted to ClassifiedRasterOutput -->
+  <action code="Exec" condition="TableExists" criteria="ecoClassify_ClassifiedRasterOutput">
+    <item>ALTER TABLE ecoClassify_ClassifiedRasterOutput ADD COLUMN ClassifiedFilteredRestricted TEXT</item>
+  </action>
+
+  <!-- Add new column PredictedFilteredRestricted to RasterOutput -->
+  <action code="Exec" condition="TableExists" criteria="ecoClassify_RasterOutput">
+    <item>ALTER TABLE ecoClassify_RasterOutput ADD COLUMN PredictedFilteredRestricted TEXT</item>
   </action>
 
 </update>


### PR DESCRIPTION
* Switched post-processing order so reclassification happens before filtering
* Reclassification step is now completely skipped if no rules rasters are present
* Added advanced classifier option defaults to update files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule-driven per-timestep reclassification with categorical and continuous rule handling; optional post-processing writes filtered restricted outputs using a provided base filename

* **Improvements**
  * Unified training and prediction flow with consistent restricted output naming and safer temporary-directory handling, per-timestep cleanup, and explicit memory management
  * More robust validation/skipping when predictors, rules, or timesteps are empty; improved NA handling during prediction
  * Updated default advanced classifier options

* **Bug Fixes**
  * Added warnings/logging when no reclassification rules exist and resilient rule loading to avoid crashes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->