### PR TITLE
Ha fixing advanced options datasheet

### DIFF
--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -423,6 +423,15 @@ if (is.null(rasterDecimalPlaces)) {
 if (is.null(contextualizationWindowSize)) {
   contextualizationWindowSize <- ""
 }
+if (is.null(manualThreshold)) {
+  manualThreshold <- ""
+}
+if (is.null(tuningObjective)) {
+  tuningObjective <- ""
+}
+if (is.null(setSeed)) {
+  setSeed <- ""
+}
 
 classifierOptionsOutputDataframe <- data.frame(
   nObs = format(nObs, scientific = FALSE),
@@ -434,10 +443,12 @@ advClassifierOptionsOutputDataframe <- data.frame(
   overrideBandnames = isTRUE(overrideBandnames),
   rasterDecimalPlaces = rasterDecimalPlaces,
   modelTuning = isTRUE(modelTuning),
+  tuningObjective = tuningObjective,
   setManualThreshold = isTRUE(setManualThreshold),
   manualThreshold = manualThreshold,
   applyContextualization = isTRUE(applyContextualization),
-  contextualizationWindowSize = contextualizationWindowSize
+  contextualizationWindowSize = contextualizationWindowSize,
+  setSeed = setSeed
 )
 
 # Save dataframes back to SyncroSim library's output datasheets ----------------

--- a/src/functions/0.4-CNN.r
+++ b/src/functions/0.4-CNN.r
@@ -586,7 +586,7 @@ predictCnnDataframe <- function(model, newdata, return = c("class", "prob")) {
       unseen <- sum(is.na(x))
       if (unseen > 0) {
         updateRunLog(sprintf(
-          "predict_cnn_dataframe: Variable '%s' contains %d unseen level(s) not present during training. They will be handled as a special 'unknown' category.",
+          "predictCnnDataframe: Variable '%s' contains %d unseen level(s) not present during training. They will be handled as a special 'unknown' category.",
           var, unseen
         ), type = "warning")
       }

--- a/src/functions/0.5-histogram.r
+++ b/src/functions/0.5-histogram.r
@@ -236,7 +236,7 @@ predictResponseHistogram <- function(rastLayerHistogram, model, modelType) {
     # Perform prediction
     preds <- tryCatch({
       if (modelType == "CNN") {
-        predict_cnn_dataframe(model, predictLayerTemp, "prob")
+        predictCnnDataframe(model, predictLayerTemp, "prob")
       } else if (modelType == "Random Forest") {
         predict(model$model, predictLayerTemp, type = "response")$predictions
       } else if (modelType == "MaxEnt") {

--- a/src/package.xml
+++ b/src/package.xml
@@ -164,6 +164,7 @@
         <dataSheet name="ClassifierOptions" type="Input"/>
         <dataSheet name="AdvancedClassifierOptions" type="Input"/>
         <dataSheet name="ModelObject" type="Input"/>
+        <dataSheet name="RasterOutput" type="Both"/>
         <dataSheet name="ClassifiedRasterOutput" type="Output"/>
         <dataSheet name="ClassifiedRgbOutput" type="Output"/>
     </transformer>

--- a/src/package.xml
+++ b/src/package.xml
@@ -161,6 +161,8 @@
     <transformer name="Predict" displayName="2-Predict" programName="Rscript" programArguments="2-predict.R" condaEnv="ecoClassify-conda.yml" condaEnvVersion="1.4">
         <dataSheet name="InputPredictingRasters" type="Input"/>
         <dataSheet name="InputPredictingCovariates" type="Input"/>
+        <dataSheet name="ClassifierOptions" type="Input"/>
+        <dataSheet name="AdvancedClassifierOptions" type="Input"/>
         <dataSheet name="ModelObject" type="Input"/>
         <dataSheet name="ClassifiedRasterOutput" type="Output"/>
         <dataSheet name="ClassifiedRgbOutput" type="Output"/>


### PR DESCRIPTION
* fixed error with `manualThreshold` data type when building `advancedClassifierOptions` datasheet
* updated `advancedClassifierOptions` datasheet to save the tuning objective, manual threshold, and seed value in results scenario
* fixed error in histogram function when CNN model is selected

NOTE: did not update package version, will be included in release for version 2.3.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tuningObjective and setSeed to advanced classifier settings.
  * Predict step now accepts classifier option inputs so prediction can use the same configuration sheets as training.

* **Bug Fixes**
  * Improved default handling for classifier options (manualThreshold, tuningObjective, setSeed) when not provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->