### PR TITLE
fixing target class bug

### DIFF
--- a/src/1-train-classifier.R
+++ b/src/1-train-classifier.R
@@ -161,7 +161,7 @@ groundTruthRasterList <- validateAndAlignRasters(
 
 if (isTRUE(useTargetClass) && !is.na(targetClassValue)) {
   timestepsWithTarget <- vapply(groundTruthRasterList, function(r) {
-    vals <- terra::values(terra::rast(r))
+    vals <- terra::values(r)
     any(vals == targetClassValue, na.rm = TRUE)
   }, logical(1))
 


### PR DESCRIPTION
Fixed bug where raster was being read without values when target class feature was applied: 
`terra::rast(r)` called on an existing SpatRaster creates a geometry-only copy with no cell values, causing `terra::values()` to return empty data. Fixed by removing the redundant `terra::rast()` wrapper and calling `terra::values(r)` directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raster value extraction in the classifier training process to ensure accurate data handling during model training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->